### PR TITLE
Add titles to data entry tabs

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
   <div class="left-panel">
+    <h2>Autre mobilité FR</h2>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.scss
@@ -4,6 +4,12 @@
   padding: 20px;
 }
 
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
 .data-entry-container {
   width: 100%;
   display: flex;

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -1,3 +1,4 @@
+<h2>Déchets</h2>
 <div *ngFor="let item of items">
   <h3>{{ item.type }}</h3>
   <label>

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.scss
@@ -4,6 +4,12 @@
   padding: 20px;
 }
 
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
 .data-entry-container {
   width: 100%;
   display: flex;

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
   <div class="left-panel">
+    <h2>Mobilité dom-trav</h2>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.scss
@@ -4,6 +4,12 @@
   padding: 20px;
 }
 
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
 .data-entry-container {
   width: 100%;
   display: flex;

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
   <div class="left-panel">
+    <h2>Émissions fugitives</h2>
     <div class="container">
       <!-- Message d'erreur -->
       <div *ngIf="hasError" class="no-data-message">

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.scss
@@ -4,6 +4,12 @@
   overflow-x: auto;
 }
 
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
 .no-data-message {
   margin-top: 1em;
   padding-bottom: 2em;

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
   <div class="left-panel">
+    <h2>Énergie</h2>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.scss
@@ -4,6 +4,12 @@
   padding: 20px;
 }
 
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
 .data-entry-container {
   width: 100%;
   display: flex;


### PR DESCRIPTION
## Summary
- add H2 headers to data entry tab pages
- apply same styling as "Autres immobilisations" for these headers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840555372fc833286ae00b04a3683b4