### PR TITLE
Align dashboard to left half

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,4 +1,5 @@
-<div class="dashboard-container">
+<div class="dashboard-page">
+  <div class="dashboard-container">
   <h2>Saisie des données</h2>
 
   <div class="dashboard-buttons" >
@@ -38,4 +39,6 @@
       </div>
     </div>
   </div>
+  </div>
+  <div class="dashboard-side"></div>
 </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -1,15 +1,26 @@
-/* Conteneur principal */
+/* Mise en page globale */
+.dashboard-page {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* Partie gauche contenant le tableau de bord */
 .dashboard-container {
   background-color: #e6f0ff;
   width: 50%;
-  margin: auto;
   padding: 2em;
-  border-radius: 20px;
+  border-radius: 20px 0 0 20px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+/* Partie droite de la page */
+.dashboard-side {
+  background-color: #fce6d5;
+  width: 50%;
 }
 
 /* Bloc des deux boutons */


### PR DESCRIPTION
## Summary
- adjust dashboard layout to mimic waste page look
- show half-screen dashboard with blue background
- add right side with orange background

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684055d9d92483328bd315fec6f75a61