### PR TITLE
Enforce positive numeric inputs

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -2,13 +2,14 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { NoNegativeDirective } from '../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [CommonModule, FormsModule]
+  imports: [NoNegativeDirective, CommonModule, FormsModule]
 })
 export class DashboardComponent {
   currentYear: number = 2024;

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -4,10 +4,11 @@ import { OngletService } from './onglet.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {AuthService} from '../../services/auth.service';
+import { NoNegativeDirective } from '../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-header-saisie-donnees',
-  imports: [CommonModule, FormsModule],
+  imports: [NoNegativeDirective, CommonModule, FormsModule],
   templateUrl: './header-saisie-donnees.component.html',
   styleUrls: ['./header-saisie-donnees.component.scss']
 })

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -2,11 +2,12 @@ import { Component, HostListener, Input, inject, signal, effect } from '@angular
 import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { NgIf, NgOptimizedImage } from '@angular/common';
+import { NoNegativeDirective } from '../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [NgOptimizedImage, NgIf],
+  imports: [NoNegativeDirective, NgOptimizedImage, NgIf],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })

--- a/frontend/src/app/components/login-page/login-page.component.ts
+++ b/frontend/src/app/components/login-page/login-page.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import {AuthService} from '../../services/auth.service';
 import {FormsModule} from '@angular/forms';
+import { NoNegativeDirective } from '../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-login-page',
-  imports: [
+  imports: [NoNegativeDirective, 
     FormsModule
   ],
   templateUrl: './login-page.component.html' ,

--- a/frontend/src/app/components/params/params.component.ts
+++ b/frontend/src/app/components/params/params.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { NoNegativeDirective } from '../../directives/no-negative.directive';
 
 interface User {
   firstName: string;
@@ -21,7 +22,7 @@ interface Entity {
 @Component({
   selector: 'app-params',
   standalone: true,
-  imports: [
+  imports: [NoNegativeDirective, 
     CommonModule,
     FormsModule
   ],

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
@@ -5,13 +5,14 @@ import { ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { CommonModule } from '@angular/common';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-achats-saisie-donnees-page',
   standalone: true,
   templateUrl: './achats-saisie-donnees-page.component.html',
   styleUrls: ['./achats-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule, HttpClientModule]
+  imports: [NoNegativeDirective, CommonModule, FormsModule, HttpClientModule]
 })
 export class AchatsSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
@@ -5,13 +5,14 @@ import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-auto-saisie-donnees-page',
   standalone: true,
   templateUrl: './auto-saisie-donnees-page.component.html',
   styleUrls: ['./auto-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule, CommonModule]
 })
 export class AutoSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -5,13 +5,14 @@ import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-saisie-donnees-page',
   standalone: true,
   templateUrl: './immob-donnees-page.component.html',
   styleUrls: ['./immob-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule, CommonModule]
 })
 export class AutreImmobilisationPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
@@ -11,13 +11,14 @@ import { TransportAutreMob } from '../../../models/transport-data.model';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { AuthService } from '../../../services/auth.service';
 import { TransportAutreMobMapperService} from './transport-data-autre-mob-mapper.service';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-autre-mob-saisie-donnees-page',
   standalone: true,
   templateUrl: './autre-mob-saisie-donnees-page.component.html',
   styleUrls: ['./autre-mob-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [NoNegativeDirective, CommonModule, FormsModule],
 })
 export class AutreMobSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import {ActivatedRoute} from '@angular/router';
 import {CommonModule} from '@angular/common';
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 import {
   EnumBatiment_TypeBatiment,
   EnumBatiment_TypeStructure,
@@ -17,7 +18,7 @@ import {
   standalone: true,
   templateUrl: './bat-saisie-donnees-page.component.html',
   styleUrls: ['./bat-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule, CommonModule]
 })
 export class BatimentsSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
@@ -9,13 +9,14 @@ import { DechetData} from '../../../models/dechet-data-model';
 import { DechetDataMapperService } from './dechet-data-mapper.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { AuthService } from '../../../services/auth.service';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-dechet-saisie-donnees-page',
   standalone: true,
   templateUrl: './dechets-saisie-donnees-page.component.html',
   styleUrls: ['./dechets-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [NoNegativeDirective, CommonModule, FormsModule],
 })
 export class DechetSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
@@ -8,13 +8,14 @@ import {AuthService} from '../../../services/auth.service';
 import {GROUPE_VOYAGEURS, MODE_TRANSPORT_DOM_TRAV} from '../../../models/enums/transport.enum';
 import {TransportDomTrav} from '../../../models/transport-data.model';
 import {TransportDataDomTravMapperService} from './transport-data-dom-trav-mapper.service';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-dom-trav-saisie-donnees-page',
   standalone: true,
   templateUrl: './dom-trav-saisie-donnees-page.component.html',
   styleUrls: ['./dom-trav-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [NoNegativeDirective, CommonModule, FormsModule],
 })
 export class DomTravSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
@@ -7,6 +7,7 @@ import {FormsModule} from '@angular/forms';
 import {TypeFluide} from '../../../models/enums/typeFluide.enum';
 import {TypeMachineEnum} from '../../../models/enums/typeMachine.enum';
 import {TypeFluideLabels} from '../../../models/typeFluide-label';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 import {TypeMachineLabels} from '../../../models/type-machine-labels'
 
 @Component({
@@ -14,7 +15,7 @@ import {TypeMachineLabels} from '../../../models/type-machine-labels'
   standalone: true,
   templateUrl: './emiss-fugi-saisie-donnees-page.component.html',
   styleUrls: ['./emiss-fugi-saisie-donnees-page.component.scss'],
-  imports: [
+  imports: [NoNegativeDirective, 
     FormsModule,
     CommonModule
   ]

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
@@ -4,13 +4,14 @@ import {HttpClient, HttpClientModule} from '@angular/common/http';
 import {ActivatedRoute} from '@angular/router'; // Permet de récupérer l'ID de l'URL
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-saisie-donnees-page',
   standalone: true,
   templateUrl: './energie-saisie-donnees-page.component.html',
   styleUrls: ['./energie-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule]
 })
 export class EnergieSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -6,13 +6,14 @@ import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { Pays } from '../../../models/enums/pays.enum';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 @Component({
   selector: 'app-destination-page',
   standalone: true,
   templateUrl: './mob-inter-saisie-donnees-page.component.html',
   styleUrls: ['./mob-inter-saisie-donnees-page.component.html'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule, CommonModule]
 })
 export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { CommonModule } from '@angular/common';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 interface EquipementNumerique {
   type: string;
@@ -20,7 +21,7 @@ interface EquipementNumerique {
   standalone: true,
   templateUrl: './numerique-saisie-donnees-page.component.html',
   styleUrls: ['./numerique-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule,CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule,CommonModule]
 })
 export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
+import { NoNegativeDirective } from '../../../directives/no-negative.directive';
 
 interface Parking {
   nom: string;
@@ -18,7 +19,7 @@ interface Parking {
   standalone: true,
   templateUrl: './park-saisie-donnees-page.component.html',
   styleUrls: ['./park-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [NoNegativeDirective, FormsModule, HttpClientModule, CommonModule]
 })
 export class ParkSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/directives/no-negative.directive.ts
+++ b/frontend/src/app/directives/no-negative.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: 'input[type=number]',
+  standalone: true
+})
+export class NoNegativeDirective {
+  constructor(private el: ElementRef<HTMLInputElement>) {
+    this.el.nativeElement.min = '0';
+  }
+
+  @HostListener('input', ['$event'])
+  onInput() {
+    const input = this.el.nativeElement;
+    if (input.value && parseFloat(input.value) < 0) {
+      input.value = '0';
+    }
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -47,3 +47,12 @@ button {
 .text-center {
   text-align: center;
 }
+/* Hide increment arrows on number inputs */
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type=number] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Summary
- add `NoNegativeDirective` to block negative numbers
- hide browser number input arrows
- apply directive across all components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684060a8fcb48332b1056d9055d8b94c