### PR TITLE
Add title to international mobility page

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -1,7 +1,9 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Saisir une destination</h2>
-    <span class="help-icon" title="Lorem ipsum">❓</span>
+    <div class="page-title">
+      <h2>Mobilité internationale</h2>
+      <span class="help-icon" title="Lorem ipsum">❓</span>
+    </div>
 
     <details>
       <summary><strong>Saisir une destination</strong></summary>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
@@ -121,4 +121,13 @@ button {
 .help-icon {
   margin-left: 0.5rem;
   cursor: pointer;
+  color: #000;
+  border: 1px solid #000;
+  border-radius: 50%;
+  padding: 0 0.4rem;
+}
+
+.page-title {
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
## Summary
- add page title and help icon container
- style help icon in a black circular button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414d224f4083328507a96399fc3cfe