### PR TITLE
Implement responsive tabs

### DIFF
--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
@@ -29,12 +29,16 @@
   <div class="nav-wrapper">
     <div class="nav-container">
       <!-- Flèche gauche -->
-      <button class="nav-arrow left" (click)="scrollLeft()" [disabled]="startIndex === 0">←</button>
+      <button class="nav-arrow left"
+              *ngIf="visibleCount < tabs.length"
+              (click)="scrollLeft()"
+              [disabled]="startIndex === 0">←</button>
 
       <!-- Conteneur des onglets -->
-      <div class="tabs-container">
-        <div class="tabs">
+      <div class="tabs-container" #tabsContainer>
+        <div class="tabs" #tabs>
           <button *ngFor="let tab of visibleTabs()"
+                  #tabBtn
                   [ngClass]="getTabClass(tab)"
                   class="tab"
                   (click)="navigateTo(tab)">
@@ -44,7 +48,10 @@
       </div>
 
       <!-- Flèche droite -->
-      <button class="nav-arrow right" (click)="scrollRight()" [disabled]="startIndex + visibleCount >= tabs.length">→
+      <button class="nav-arrow right"
+              *ngIf="visibleCount < tabs.length"
+              (click)="scrollRight()"
+              [disabled]="startIndex + visibleCount >= tabs.length">→
       </button>
     </div>
   </div>

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.scss
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.scss
@@ -130,7 +130,10 @@ body {
   font-size: 0.9em;
   height: 2.81em;
   min-width: 5.62em;
+  max-width: 8.5em;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tab:hover {

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, AfterViewInit, ElementRef, ViewChild, ViewChildren, QueryList, HostListener } from '@angular/core';
 import { Router } from '@angular/router';
 import { OngletService } from './onglet.service';
 import { CommonModule } from '@angular/common';
@@ -11,7 +11,7 @@ import {AuthService} from '../../services/auth.service';
   templateUrl: './header-saisie-donnees.component.html',
   styleUrls: ['./header-saisie-donnees.component.scss']
 })
-export class HeaderSaisieDonneesComponent implements OnInit {
+export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
   constructor(private router: Router, private ongletService: OngletService, private auth: AuthService) {
     this.currentYear = new Date().getFullYear();
     this.years = Array.from({ length: this.currentYear - 2018 }, (_, i) => this.currentYear - i);
@@ -41,8 +41,36 @@ export class HeaderSaisieDonneesComponent implements OnInit {
   selectedYear: number;
   years: number[] = [];
 
+  @ViewChild('tabsContainer') tabsContainer!: ElementRef<HTMLDivElement>;
+  @ViewChild('tabs') tabsRef!: ElementRef<HTMLDivElement>;
+  @ViewChildren('tabBtn') tabButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
   ngOnInit(): void {
     this.loadOngletIds();
+  }
+
+  ngAfterViewInit(): void {
+    this.updateVisibleCount();
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.updateVisibleCount();
+  }
+
+  updateVisibleCount() {
+    if (!this.tabsContainer || this.tabButtons.length === 0) return;
+
+    const containerWidth = this.tabsContainer.nativeElement.offsetWidth;
+    const tabWidth = this.tabButtons.first.nativeElement.offsetWidth;
+    const gap = parseFloat(getComputedStyle(this.tabsRef.nativeElement).gap || '0');
+
+    const count = Math.floor((containerWidth + gap) / (tabWidth + gap));
+    this.visibleCount = Math.max(1, Math.min(this.tabs.length, count));
+
+    if (this.startIndex + this.visibleCount > this.tabs.length) {
+      this.startIndex = Math.max(0, this.tabs.length - this.visibleCount);
+    }
   }
 
   loadOngletIds(): void {


### PR DESCRIPTION
## Summary
- show scroll arrows only when all tabs don't fit
- limit tab text width to avoid overflow
- compute visible tab count on resize

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684158508a2c8332a8f2d7b05703cf80