### PR TITLE
Add persistent save button with loader

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -12,4 +12,6 @@
 
   <!-- Contenu principal (formulaires, tableaux, etc.) -->
   <router-outlet></router-outlet>
+
+  <app-save-footer></app-save-footer>
 </div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -5,12 +5,20 @@ import {RouterOutlet} from '@angular/router';
 import {ActivatedRoute, NavigationEnd, Router, RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
 import {HeaderSaisieDonneesComponent} from './components/header-saisie-donnees/header-saisie-donnees.component';
+import {SaveFooterComponent} from './components/save-footer/save-footer.component';
 import {filter, map, mergeMap} from 'rxjs';
 
 @Component({
   selector: 'app-root',
 
-  imports: [CommonModule, RouterOutlet, HeaderComponent, RouterModule, HeaderSaisieDonneesComponent],
+  imports: [
+    CommonModule,
+    RouterOutlet,
+    HeaderComponent,
+    RouterModule,
+    HeaderSaisieDonneesComponent,
+    SaveFooterComponent,
+  ],
 
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'

--- a/frontend/src/app/components/save-footer/save-footer.component.html
+++ b/frontend/src/app/components/save-footer/save-footer.component.html
@@ -1,0 +1,4 @@
+<div class="save-footer">
+  <button class="save-button" (click)="save()" [disabled]="loading">Sauvegarder</button>
+  <div class="loader" *ngIf="loading"></div>
+</div>

--- a/frontend/src/app/components/save-footer/save-footer.component.scss
+++ b/frontend/src/app/components/save-footer/save-footer.component.scss
@@ -1,0 +1,26 @@
+.save-footer {
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+  position: relative;
+}
+
+.save-button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
+.loader {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #1976d2;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  margin-left: 1rem;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/frontend/src/app/components/save-footer/save-footer.component.ts
+++ b/frontend/src/app/components/save-footer/save-footer.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-save-footer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './save-footer.component.html',
+  styleUrls: ['./save-footer.component.scss']
+})
+export class SaveFooterComponent {
+  loading = false;
+
+  save(): void {
+    this.loading = true;
+    setTimeout(() => {
+      this.loading = false;
+    }, 2000);
+  }
+}


### PR DESCRIPTION
## Summary
- show a global save button at the bottom of every page
- display a simple loader for two seconds when clicking the button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415ac2cf3c83329a4165ab493e9d6a