### PR TITLE
Move save button into each tab

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -13,5 +13,4 @@
   <!-- Contenu principal (formulaires, tableaux, etc.) -->
   <router-outlet></router-outlet>
 
-  <app-save-footer></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -108,3 +108,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
@@ -5,13 +5,14 @@ import { ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { CommonModule } from '@angular/common';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-achats-saisie-donnees-page',
   standalone: true,
   templateUrl: './achats-saisie-donnees-page.component.html',
   styleUrls: ['./achats-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule, HttpClientModule]
+  imports: [CommonModule, FormsModule, HttpClientModule, SaveFooterComponent]
 })
 export class AchatsSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-inter-saisie-donnees-page.component.html
@@ -3,3 +3,4 @@
     
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -49,3 +49,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 
@@ -11,7 +12,7 @@ import { ApiEndpoints } from '../../../services/api-endpoints';
   standalone: true,
   templateUrl: './auto-saisie-donnees-page.component.html',
   styleUrls: ['./auto-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class AutoSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -123,3 +123,4 @@
     </table>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 
@@ -11,7 +12,7 @@ import { ApiEndpoints } from '../../../services/api-endpoints';
   standalone: true,
   templateUrl: './immob-donnees-page.component.html',
   styleUrls: ['./immob-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class AutreImmobilisationPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
@@ -42,3 +42,4 @@
     </table>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
@@ -11,13 +11,14 @@ import { TransportAutreMob } from '../../../models/transport-data.model';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { AuthService } from '../../../services/auth.service';
 import { TransportAutreMobMapperService} from './transport-data-autre-mob-mapper.service';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-autre-mob-saisie-donnees-page',
   standalone: true,
   templateUrl: './autre-mob-saisie-donnees-page.component.html',
   styleUrls: ['./autre-mob-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, SaveFooterComponent],
 })
 export class AutreMobSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -227,3 +227,4 @@
   </div>
   <hr />
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import {ActivatedRoute} from '@angular/router';
 import {CommonModule} from '@angular/common';
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import {
   EnumBatiment_TypeBatiment,
   EnumBatiment_TypeStructure,
@@ -17,7 +18,7 @@ import {
   standalone: true,
   templateUrl: './bat-saisie-donnees-page.component.html',
   styleUrls: ['./bat-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class BatimentsSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -14,4 +14,4 @@
   </label>
 </div>
 
-<button (click)="updateData()">Enregistrer</button>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
@@ -9,13 +9,14 @@ import { DechetData} from '../../../models/dechet-data-model';
 import { DechetDataMapperService } from './dechet-data-mapper.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { AuthService } from '../../../services/auth.service';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-dechet-saisie-donnees-page',
   standalone: true,
   templateUrl: './dechets-saisie-donnees-page.component.html',
   styleUrls: ['./dechets-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, SaveFooterComponent],
 })
 export class DechetSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -43,3 +43,4 @@
     </table>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
@@ -8,13 +8,14 @@ import {AuthService} from '../../../services/auth.service';
 import {GROUPE_VOYAGEURS, MODE_TRANSPORT_DOM_TRAV} from '../../../models/enums/transport.enum';
 import {TransportDomTrav} from '../../../models/transport-data.model';
 import {TransportDataDomTravMapperService} from './transport-data-dom-trav-mapper.service';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-dom-trav-saisie-donnees-page',
   standalone: true,
   templateUrl: './dom-trav-saisie-donnees-page.component.html',
   styleUrls: ['./dom-trav-saisie-donnees-page.component.scss'],
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, SaveFooterComponent],
 })
 export class DomTravSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -114,3 +114,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
@@ -8,6 +8,7 @@ import {TypeFluide} from '../../../models/enums/typeFluide.enum';
 import {TypeMachineEnum} from '../../../models/enums/typeMachine.enum';
 import {TypeFluideLabels} from '../../../models/typeFluide-label';
 import {TypeMachineLabels} from '../../../models/type-machine-labels'
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -16,7 +17,8 @@ import {TypeMachineLabels} from '../../../models/type-machine-labels'
   styleUrls: ['./emiss-fugi-saisie-donnees-page.component.scss'],
   imports: [
     FormsModule,
-    CommonModule
+    CommonModule,
+    SaveFooterComponent
   ]
 })
 export class EmissFugiSaisieDonneesPageComponent implements OnInit {

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
@@ -66,3 +66,4 @@
     </table>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
@@ -4,13 +4,14 @@ import {HttpClient, HttpClientModule} from '@angular/common/http';
 import {ActivatedRoute} from '@angular/router'; // Permet de récupérer l'ID de l'URL
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-saisie-donnees-page',
   standalone: true,
   templateUrl: './energie-saisie-donnees-page.component.html',
   styleUrls: ['./energie-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule]
+  imports: [FormsModule, HttpClientModule, SaveFooterComponent]
 })
 export class EnergieSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -81,3 +81,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -6,13 +6,14 @@ import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { Pays } from '../../../models/enums/pays.enum';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
   selector: 'app-destination-page',
   standalone: true,
   templateUrl: './mob-inter-saisie-donnees-page.component.html',
   styleUrls: ['./mob-inter-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -99,3 +99,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { CommonModule } from '@angular/common';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 interface EquipementNumerique {
   type: string;
@@ -20,7 +21,7 @@ interface EquipementNumerique {
   standalone: true,
   templateUrl: './numerique-saisie-donnees-page.component.html',
   styleUrls: ['./numerique-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule,CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -54,3 +54,4 @@
     </div>
   </div>
 </div>
+<app-save-footer></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
+import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 interface Parking {
   nom: string;
@@ -18,7 +19,7 @@ interface Parking {
   standalone: true,
   templateUrl: './park-saisie-donnees-page.component.html',
   styleUrls: ['./park-saisie-donnees-page.component.scss'],
-  imports: [FormsModule, HttpClientModule, CommonModule]
+  imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class ParkSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);

--- a/frontend/src/app/components/save-footer/save-footer.component.scss
+++ b/frontend/src/app/components/save-footer/save-footer.component.scss
@@ -6,8 +6,19 @@
 }
 
 .save-button {
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
+  text-align: center;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 0.56em 1.12em;
+  font-size: 0.9em;
+  cursor: pointer;
+  border-radius: 0.3em;
+  transition: background-color 0.3s;
+}
+
+.save-button:hover {
+  background-color: #0056b3;
 }
 
 .loader {


### PR DESCRIPTION
## Summary
- move `<app-save-footer>` from app root into every data entry tab
- style save button like header buttons
- remove custom "Enregistrer" button from Dechets page
- import `SaveFooterComponent` in each tab component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415c2648a083329e9c0f4008adb3f5