### PR TITLE
Add Terminé button with dashboard sync

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -22,8 +22,8 @@
   <div class="status-grid">
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(0, 6)">
-        <span class="icon" [ngClass]="onglet.status ? 'green' : 'red'">
-          {{ onglet.status ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.path) ? 'green' : 'red'">
+          {{ getStatus(onglet.path) ? '✅' : '❌' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet.path)">✏️</span>
@@ -31,8 +31,8 @@
     </div>
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(6)">
-        <span class="icon" [ngClass]="onglet.status ? 'green' : 'red'">
-          {{ onglet.status ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.path) ? 'green' : 'red'">
+          {{ getStatus(onglet.path) ? '✅' : '❌' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet.path)">✏️</span>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { OngletStatusService } from '../../services/onglet-status.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -28,7 +29,11 @@ export class DashboardComponent {
     { label: 'Déchets', status: true, path: 'dechetsOnglet' }
   ];
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private statusService: OngletStatusService) {}
+
+  getStatus(path: string): boolean {
+    return this.statusService.getStatus(path);
+  }
 
   goToSaisie(path: string): void {
     this.router.navigate([`/${path}/${this.currentYear}`]);

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -115,4 +115,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'achatsOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-inter-saisie-donnees-page.component.html
@@ -3,4 +3,4 @@
     
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'autoOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -49,4 +49,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'autoOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -126,6 +126,6 @@
         </table>
       </div>
     </div>
-    <app-save-footer></app-save-footer>
+    <app-save-footer [path]="'immobOnglet'"></app-save-footer>
   </div>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
@@ -42,4 +42,4 @@
     </table>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'autreMobFrOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -227,4 +227,4 @@
   </div>
   <hr />
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'batimentsOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -28,4 +28,4 @@
   </div>
 </div>
 
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'dechetsOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -43,4 +43,4 @@
     </table>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'mobiliteDomTravOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -114,4 +114,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'emissionsFugitivesOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
@@ -66,4 +66,4 @@
     </table>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'energieOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -84,4 +84,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'mobiliteInternationaleOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -99,4 +99,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'numeriqueOnglet'"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -54,4 +54,4 @@
     </div>
   </div>
 </div>
-<app-save-footer></app-save-footer>
+<app-save-footer [path]="'parkingsOnglet'"></app-save-footer>

--- a/frontend/src/app/components/save-footer/save-footer.component.html
+++ b/frontend/src/app/components/save-footer/save-footer.component.html
@@ -1,4 +1,5 @@
 <div class="save-footer">
   <button class="save-button" (click)="save()" [disabled]="loading">Sauvegarder</button>
+  <button class="termine-button" (click)="toggleTermine()">Terminé</button>
   <div class="loader" *ngIf="loading"></div>
 </div>

--- a/frontend/src/app/components/save-footer/save-footer.component.scss
+++ b/frontend/src/app/components/save-footer/save-footer.component.scss
@@ -17,6 +17,22 @@
   transition: background-color 0.3s;
 }
 
+.termine-button {
+  margin-left: 1rem;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  padding: 0.56em 1.12em;
+  font-size: 0.9em;
+  cursor: pointer;
+  border-radius: 0.3em;
+  transition: background-color 0.3s;
+}
+
+.termine-button:hover {
+  background-color: #1e7e34;
+}
+
 .save-button:hover {
   background-color: #0056b3;
 }

--- a/frontend/src/app/components/save-footer/save-footer.component.ts
+++ b/frontend/src/app/components/save-footer/save-footer.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { OngletStatusService } from '../../services/onglet-status.service';
 
 @Component({
   selector: 'app-save-footer',
@@ -8,13 +9,30 @@ import { CommonModule } from '@angular/common';
   templateUrl: './save-footer.component.html',
   styleUrls: ['./save-footer.component.scss']
 })
-export class SaveFooterComponent {
+export class SaveFooterComponent implements OnInit {
+  @Input() path = '';
   loading = false;
+  estTermine = false;
+
+  constructor(private statusService: OngletStatusService) {}
+
+  ngOnInit(): void {
+    if (this.path) {
+      this.estTermine = this.statusService.getStatus(this.path);
+    }
+  }
 
   save(): void {
     this.loading = true;
     setTimeout(() => {
       this.loading = false;
     }, 2000);
+  }
+
+  toggleTermine(): void {
+    this.estTermine = !this.estTermine;
+    if (this.path) {
+      this.statusService.setStatus(this.path, this.estTermine);
+    }
   }
 }

--- a/frontend/src/app/services/onglet-status.service.ts
+++ b/frontend/src/app/services/onglet-status.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class OngletStatusService {
+  private statuses = new BehaviorSubject<Record<string, boolean>>({});
+  statuses$ = this.statuses.asObservable();
+
+  setStatus(path: string, status: boolean): void {
+    const current = this.statuses.getValue();
+    this.statuses.next({ ...current, [path]: status });
+  }
+
+  getStatus(path: string): boolean {
+    return this.statuses.getValue()[path] ?? false;
+  }
+}


### PR DESCRIPTION
## Summary
- create OngletStatusService to track completion state
- show Terminé button through SaveFooter component
- store completion state in OngletStatusService when button clicked
- display status in dashboard using OngletStatusService
- link each page's footer with its dashboard path

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416950a0c8833292e8a5592472bb10