### PR TITLE
Fix dynamic EnergieOnglet endpoints

### DIFF
--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -2,8 +2,8 @@ const BASE_URL = 'http://localhost:8080';
 
 export const ApiEndpoints = {
   EnergieOnglet: {
-    getById: (id: string) => `${BASE_URL}/energieonglet/58`,
-    updateConso: (id: string) => `${BASE_URL}/energieonglet/58`,
+    getById: (id: string) => `${BASE_URL}/energieonglet/${id}`,
+    updateConso: (id: string) => `${BASE_URL}/energieonglet/${id}`,
     // autres méthodes PATCH (comme /consoGaz, /consoFioul, etc.)
     patchConsoGaz: (id: string) => `${BASE_URL}/energieonglet/${id}/consoGaz`,
     patchNote: (id: string) => `${BASE_URL}/energieonglet/${id}/note`,


### PR DESCRIPTION
## Summary
- pass the provided id to EnergieOnglet's `getById` and `updateConso` endpoints

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418ce86744833289b615fcf5f146f9