### PR TITLE
Add completion status to energy updates

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
@@ -4,6 +4,7 @@ import {HttpClient, HttpClientModule} from '@angular/common/http';
 import {ActivatedRoute} from '@angular/router'; // Permet de récupérer l'ID de l'URL
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
+import {OngletStatusService} from '../../../services/onglet-status.service';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
@@ -17,10 +18,16 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);
   private route = inject(ActivatedRoute); // Récupération des paramètres de l'URL
   private authService = inject(AuthService);
+  private statusService = inject(OngletStatusService);
 
   items: any = {}; // Objet qui contiendra les données récupérées
+  estTermine = false;
 
   ngOnInit() {
+    this.estTermine = this.statusService.getStatus('energieOnglet');
+    this.statusService.statuses$.subscribe(statuses => {
+      this.estTermine = statuses['energieOnglet'] ?? false;
+    });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
       if (id) {
@@ -85,7 +92,8 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
           consoReseauVille: this.items.consoReseauVille,
           consoElecChauffage: this.items.consoElecChauffage,
           consoElecSpecifique: this.items.consoElecSpecifique,
-          consoEau: this.items.consoEau
+          consoEau: this.items.consoEau,
+          estTermine: this.estTermine
         },
         {headers}
       ).subscribe({


### PR DESCRIPTION
## Summary
- track tab completion status in EnergieSaisieDonneesPageComponent
- send `estTermine` with PATCH requests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419172d1b48332b1301b964ba3e786