### PR TITLE
Implement achat patch

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -115,4 +115,4 @@
     </div>
   </div>
 </div>
-<app-save-footer [path]="'achatsOnglet'"></app-save-footer>
+<app-save-footer [path]="'achatsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { CommonModule } from '@angular/common';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
+import { OngletStatusService } from '../../../services/onglet-status.service';
 
 @Component({
   selector: 'app-achats-saisie-donnees-page',
@@ -18,10 +19,21 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
   private http = inject(HttpClient);
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
+  private statusService = inject(OngletStatusService);
 
   items: any = {};
+  estTermine = false;
+
+  onEstTermineChange(value: boolean): void {
+    this.estTermine = value;
+    this.updateAchat();
+  }
 
   ngOnInit() {
+    this.estTermine = this.statusService.getStatus('achatsOnglet');
+    this.statusService.statuses$.subscribe(statuses => {
+      this.estTermine = statuses['achatsOnglet'] ?? false;
+    });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
       if (id) this.loadData(id);
@@ -91,5 +103,67 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
       },
       (err) => console.error("Erreur de chargement", err)
     );
+  }
+
+  updateAchat(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    const token = this.authService.getToken();
+    if (!id || !token) return;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+
+    const payload = {
+      papierCons: this.items.papierCons,
+      livresCons: this.items.livresCons,
+      cartonNeufCons: this.items.cartonNeufCons,
+      cartonRecycleCons: this.items.cartonRecycleCons,
+      fournituresCons: this.items.fournituresCons,
+      jetEncreConsTonnes: this.items.jetEncreConsTonnes,
+      jetEncreConsRamettes: this.items.jetEncreConsRamettes,
+      tonerConsTonnes: this.items.tonerConsTonnes,
+      tonerConsRamettes: this.items.tonerConsRamettes,
+      feuillesJetEncreCons: this.items.jetEncreCons,
+      feuillesTonerCons: this.items.tonerCons,
+      pharmaCons: this.items.pharmaCons,
+      servicesCons: this.items.servicesCons,
+      serviceEnseignementCons: this.items.serviceEnseignementCons,
+      serviceProduitsInformatiqueCons: this.items.serviceProduitsInformatiqueCons,
+      serviceReparationsMachinesCons: this.items.serviceReparationsMachinesCons,
+      serviceTransportCons: this.items.serviceTransportCons,
+      serviceHebergementRestaurationCons: this.items.serviceHebergementRestaurationCons,
+      serviceTelecomCons: this.items.serviceTelecomCons,
+
+      papierTextile: this.items.papierTextile,
+      livresTextile: this.items.livresTextile,
+      cartonNeufTextile: this.items.cartonNeufTextile,
+      cartonRecycleTextile: this.items.cartonRecycleTextile,
+      fournituresTextile: this.items.fournituresTextile,
+      jetEncreTextileTonnes: this.items.jetEncreTextileTonnes,
+      jetEncreTextileRamettes: this.items.jetEncreTextileRamettes,
+      tonerTextileTonnes: this.items.tonerTextileTonnes,
+      tonerTextileRamettes: this.items.tonerTextileRamettes,
+      feuillesJetEncreTextile: this.items.jetEncreTextile,
+      feuillesTonerTextile: this.items.tonerTextile,
+      pharmaTextile: this.items.pharmaTextile,
+
+      bilanCarboneRestauration: this.items.hasBilanCarbone ? this.items.bilanCarboneTotal : null,
+      connaitQuantiteAliment: this.items.connaitQuantiteAliments,
+      quantiteBoeuf: this.items.boeuf,
+      quantitePoisson: this.items.poisson,
+      quantiteFromage: this.items.fromage,
+      quantiteBoisson: this.items.boisson,
+      connaitRepasParType: this.items.connaitRepasParType,
+      repasAnimal: this.items.repasAnimal,
+      repasVegetal: this.items.repasVegetal,
+      repasVegetarien: this.items.repasVegetarien,
+      estTermine: this.estTermine
+    };
+
+    this.http.patch(ApiEndpoints.AchatsOnglet.update(id), payload, { headers }).subscribe({
+      error: err => console.error('PATCH achats échoué', err)
+    });
   }
 }

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -34,6 +34,7 @@ export const ApiEndpoints = {
 
   AchatsOnglet: {
     getById: (id: string) => `${BASE_URL}/achatOnglet/${id}`,
+    update: (id: string) => `${BASE_URL}/achatOnglet/${id}`,
   },
 
 ImmobOnglet: {


### PR DESCRIPTION
## Summary
- add update endpoint for Achats
- wire up status change and update logic in Achats page
- emit estTermine changes from save footer

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684197124e68833285523ce20602f65b