### PR TITLE
Add numerique mapping and models

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { EquipementNumerique, NumeriqueOnglet } from '../../../models/numerique.model';
+import { NUMERIQUE_EQUIPEMENT } from '../../../models/enums/numerique.enum';
+
+@Injectable({ providedIn: 'root' })
+export class NumeriqueOngletMapperService {
+  fromDto(dto: any): NumeriqueOnglet {
+    const equipements: EquipementNumerique[] = (dto.equipementNumeriqueList || []).map((e: any) => ({
+      id: e.id,
+      equipement: e.equipement as NUMERIQUE_EQUIPEMENT,
+      nombre: e.nombre ?? null,
+      dureeAmortissement: e.dureeAmortissement ?? null,
+      emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues ?? false,
+      emissionsReellesParProduitKgCO2e: e.emissionsReellesParProduitKgCO2e ?? null,
+      anneeAjout: e.anneeAjout,
+    }));
+
+    return {
+      estTermine: dto.estTermine ?? false,
+      note: dto.note ?? '',
+      cloudDataDisponible: dto.cloudData?.disponible ?? null,
+      traficCloud: dto.cloudData?.trafic ?? null,
+      tipUtilisateur: dto.cloudData?.tip ?? null,
+      equipements,
+    };
+  }
+
+  toDto(model: NumeriqueOnglet): any {
+    return {
+      estTermine: model.estTermine,
+      note: model.note,
+      cloudData: {
+        disponible: model.cloudDataDisponible,
+        trafic: model.traficCloud,
+        tip: model.tipUtilisateur,
+      },
+      equipementNumeriqueList: model.equipements.map(e => ({
+        id: e.id,
+        equipement: e.equipement,
+        nombre: e.nombre,
+        dureeAmortissement: e.dureeAmortissement,
+        emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues,
+        emissionsReellesParProduitKgCO2e: e.emissionsReellesParProduitKgCO2e,
+      })),
+    };
+  }
+}

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -21,7 +21,7 @@
 
       <div class="form-column">
         <label>Type d'équipement</label>
-        <select [(ngModel)]="nouvelEquipement.type">
+        <select [(ngModel)]="nouvelEquipement.equipement">
           <option value="Ecran">Écran</option>
           <option value="Ordinateur">Ordinateur</option>
           <option value="Serveur">Serveur</option>
@@ -30,19 +30,19 @@
         </select>
 
         <label>Quantité</label>
-        <input type="number" [(ngModel)]="nouvelEquipement.quantite" />
+        <input type="number" [(ngModel)]="nouvelEquipement.nombre" />
 
         <label>Durée d’amortissement (années)</label>
-        <input type="number" [(ngModel)]="nouvelEquipement.amortissement" />
+        <input type="number" [(ngModel)]="nouvelEquipement.dureeAmortissement" />
 
         <label>Émissions de GES connues ?</label>
-        <select [(ngModel)]="nouvelEquipement.gesConnu">
+        <select [(ngModel)]="nouvelEquipement.emissionsGesPrecisesConnues">
           <option [ngValue]="false" selected>Non</option>
           <option [ngValue]="true">Oui</option>
         </select>
 
-        <label *ngIf="nouvelEquipement.gesConnu">Émissions de GES réelles (kgCO2/équipement)</label>
-        <input *ngIf="nouvelEquipement.gesConnu" type="number" [(ngModel)]="nouvelEquipement.gesReel" />
+        <label *ngIf="nouvelEquipement.emissionsGesPrecisesConnues">Émissions de GES réelles (kgCO2/équipement)</label>
+        <input *ngIf="nouvelEquipement.emissionsGesPrecisesConnues" type="number" [(ngModel)]="nouvelEquipement.emissionsReellesParProduitKgCO2e" />
       </div>
 
       <button type="button" (click)="ajouterEquipement()">Ajouter cet équipement</button>
@@ -62,11 +62,11 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAjoutes">
-            <td>{{ equipement.type }}</td>
-            <td>{{ equipement.quantite }}</td>
-            <td>{{ equipement.amortissement }}</td>
-            <td>{{ equipement.gesConnu ? 'Oui' : 'Non' }}</td>
-            <td>{{ equipement.gesReel ?? 'N/A' }}</td>
+            <td>{{ equipement.equipement }}</td>
+            <td>{{ equipement.nombre }}</td>
+            <td>{{ equipement.dureeAmortissement }}</td>
+            <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
+            <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
           </tr>
         </tbody>
       </table>
@@ -87,11 +87,11 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAnciens">
-            <td>{{ equipement.type }}</td>
-            <td>{{ equipement.quantite }}</td>
-            <td>{{ equipement.amortissement }}</td>
-            <td>{{ equipement.gesConnu ? 'Oui' : 'Non' }}</td>
-            <td>{{ equipement.gesReel ?? 'N/A' }}</td>
+            <td>{{ equipement.equipement }}</td>
+            <td>{{ equipement.nombre }}</td>
+            <td>{{ equipement.dureeAmortissement }}</td>
+            <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
+            <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
             <td>{{ equipement.anneeAjout }}</td>
           </tr>
         </tbody>

--- a/frontend/src/app/models/enums/numerique.enum.ts
+++ b/frontend/src/app/models/enums/numerique.enum.ts
@@ -1,0 +1,7 @@
+export enum NUMERIQUE_EQUIPEMENT {
+  ECRAN = 'Ecran',
+  ORDINATEUR = 'Ordinateur',
+  SERVEUR = 'Serveur',
+  ROUTEUR = 'Routeur',
+  SWITCH = 'Switch'
+}

--- a/frontend/src/app/models/numerique.model.ts
+++ b/frontend/src/app/models/numerique.model.ts
@@ -1,0 +1,20 @@
+import { NUMERIQUE_EQUIPEMENT } from './enums/numerique.enum';
+
+export interface EquipementNumerique {
+  id?: number;
+  equipement: NUMERIQUE_EQUIPEMENT | string;
+  nombre: number | null;
+  dureeAmortissement: number | null;
+  emissionsGesPrecisesConnues: boolean;
+  emissionsReellesParProduitKgCO2e: number | null;
+  anneeAjout?: number;
+}
+
+export interface NumeriqueOnglet {
+  estTermine?: boolean;
+  note?: string;
+  cloudDataDisponible: boolean | null;
+  traficCloud: number | null;
+  tipUtilisateur: number | null;
+  equipements: EquipementNumerique[];
+}


### PR DESCRIPTION
## Summary
- implement numeric equipment enum and models
- add mapper for numerique onglet
- refactor numerique component to use mapper and new model

## Testing
- `npm test --prefix frontend --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a25ce7108332ae3bb5d515ad9b2e