### PR TITLE
Update numérique enum and mapping

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
@@ -4,10 +4,16 @@ import { NUMERIQUE_EQUIPEMENT } from '../../../models/enums/numerique.enum';
 
 @Injectable({ providedIn: 'root' })
 export class NumeriqueOngletMapperService {
+  private normalizeEquipement(value: string): NUMERIQUE_EQUIPEMENT | string {
+    const upper = value?.toUpperCase();
+    const found = (Object.values(NUMERIQUE_EQUIPEMENT) as string[]).find(v => v.toUpperCase() === upper);
+    return (found as NUMERIQUE_EQUIPEMENT) || value;
+  }
+
   fromDto(dto: any): NumeriqueOnglet {
     const equipements: EquipementNumerique[] = (dto.equipementNumeriqueList || []).map((e: any) => ({
       id: e.id,
-      equipement: e.equipement as NUMERIQUE_EQUIPEMENT,
+      equipement: this.normalizeEquipement(e.equipement),
       nombre: e.nombre ?? null,
       dureeAmortissement: e.dureeAmortissement ?? null,
       emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues ?? false,
@@ -18,9 +24,10 @@ export class NumeriqueOngletMapperService {
     return {
       estTermine: dto.estTermine ?? false,
       note: dto.note ?? '',
-      cloudDataDisponible: dto.cloudData?.disponible ?? null,
-      traficCloud: dto.cloudData?.trafic ?? null,
-      tipUtilisateur: dto.cloudData?.tip ?? null,
+      cloudDataDisponible: dto.cloudData?.disponible ?? dto.cloudDataDisponible ?? null,
+      traficCloud: dto.cloudData?.trafic ?? dto.TraficCloudUtilisateur ?? null,
+      tipUtilisateur: dto.cloudData?.tip ?? dto.TraficTipUtilisateur ?? null,
+      partTraficFranceEtranger: dto.cloudData?.partTraficFranceEtranger ?? dto.PartTraficFranceEtranger ?? null,
       equipements,
     };
   }
@@ -29,14 +36,13 @@ export class NumeriqueOngletMapperService {
     return {
       estTermine: model.estTermine,
       note: model.note,
-      cloudData: {
-        disponible: model.cloudDataDisponible,
-        trafic: model.traficCloud,
-        tip: model.tipUtilisateur,
-      },
+      cloudDataDisponible: model.cloudDataDisponible,
+      TraficCloudUtilisateur: model.traficCloud,
+      TraficTipUtilisateur: model.tipUtilisateur,
+      PartTraficFranceEtranger: (model as any).partTraficFranceEtranger,
       equipementNumeriqueList: model.equipements.map(e => ({
         id: e.id,
-        equipement: e.equipement,
+        equipement: typeof e.equipement === 'string' ? e.equipement : e.equipement.toString(),
         nombre: e.nombre,
         dureeAmortissement: e.dureeAmortissement,
         emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues,

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -22,11 +22,9 @@
       <div class="form-column">
         <label>Type d'équipement</label>
         <select [(ngModel)]="nouvelEquipement.equipement">
-          <option value="Ecran">Écran</option>
-          <option value="Ordinateur">Ordinateur</option>
-          <option value="Serveur">Serveur</option>
-          <option value="Routeur">Routeur</option>
-          <option value="Switch">Switch</option>
+          <option *ngFor="let entry of equipementOptions" [ngValue]="entry.value">
+            {{ entry.label }}
+          </option>
         </select>
 
         <label>Quantité</label>
@@ -62,7 +60,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAjoutes">
-            <td>{{ equipement.equipement }}</td>
+            <td>{{ numeriqueEquipmentLabels[equipement.equipement as string] }}</td>
             <td>{{ equipement.nombre }}</td>
             <td>{{ equipement.dureeAmortissement }}</td>
             <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
@@ -87,7 +85,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAnciens">
-            <td>{{ equipement.equipement }}</td>
+            <td>{{ numeriqueEquipmentLabels[equipement.equipement as string] }}</td>
             <td>{{ equipement.nombre }}</td>
             <td>{{ equipement.dureeAmortissement }}</td>
             <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -10,6 +10,7 @@ import { OngletStatusService } from '../../../services/onglet-status.service';
 import { NumeriqueOngletMapperService } from './numerique-onglet-mapper.service';
 import { EquipementNumerique, NumeriqueOnglet } from '../../../models/numerique.model';
 import { NUMERIQUE_EQUIPEMENT } from '../../../models/enums/numerique.enum';
+import { NumeriqueEquipmentLabels } from '../../../models/numerique-equipment-labels';
 
 @Component({
   selector: 'app-numerique-saisie-donnees-page',
@@ -36,6 +37,13 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
     emissionsGesPrecisesConnues: false,
     emissionsReellesParProduitKgCO2e: null
   };
+
+  equipementOptions = Object.keys(NUMERIQUE_EQUIPEMENT).map(key => {
+    const value = NUMERIQUE_EQUIPEMENT[key as keyof typeof NUMERIQUE_EQUIPEMENT];
+    return { value, label: NumeriqueEquipmentLabels[value] };
+  });
+
+  numeriqueEquipmentLabels = NumeriqueEquipmentLabels;
 
   equipementsAjoutes: EquipementNumerique[] = [];
   equipementsAnciens: EquipementNumerique[] = [];

--- a/frontend/src/app/models/enums/numerique.enum.ts
+++ b/frontend/src/app/models/enums/numerique.enum.ts
@@ -1,7 +1,7 @@
 export enum NUMERIQUE_EQUIPEMENT {
-  ECRAN = 'Ecran',
-  ORDINATEUR = 'Ordinateur',
-  SERVEUR = 'Serveur',
-  ROUTEUR = 'Routeur',
-  SWITCH = 'Switch'
+  ECRAN = 'ECRAN',
+  ORDINATEUR = 'ORDINATEUR',
+  SERVEUR = 'SERVEUR',
+  ROUTEUR = 'ROUTEUR',
+  SWITCH = 'SWITCH'
 }

--- a/frontend/src/app/models/numerique-equipment-labels.ts
+++ b/frontend/src/app/models/numerique-equipment-labels.ts
@@ -1,0 +1,9 @@
+import { NUMERIQUE_EQUIPEMENT } from './enums/numerique.enum';
+
+export const NumeriqueEquipmentLabels: Record<NUMERIQUE_EQUIPEMENT, string> = {
+  [NUMERIQUE_EQUIPEMENT.ECRAN]: 'Écran',
+  [NUMERIQUE_EQUIPEMENT.ORDINATEUR]: 'Ordinateur',
+  [NUMERIQUE_EQUIPEMENT.SERVEUR]: 'Serveur',
+  [NUMERIQUE_EQUIPEMENT.ROUTEUR]: 'Routeur',
+  [NUMERIQUE_EQUIPEMENT.SWITCH]: 'Switch',
+};

--- a/frontend/src/app/models/numerique.model.ts
+++ b/frontend/src/app/models/numerique.model.ts
@@ -16,5 +16,6 @@ export interface NumeriqueOnglet {
   cloudDataDisponible: boolean | null;
   traficCloud: number | null;
   tipUtilisateur: number | null;
+  partTraficFranceEtranger?: number | null;
   equipements: EquipementNumerique[];
 }


### PR DESCRIPTION
## Summary
- sync numerique enum values with backend constants
- add labels for numerique equipments
- use mapping to display equipment labels
- handle new numerique backend fields and enum mapping

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6ba5d008332b47e24f707007ede