### PR TITLE
Update NUMERIQUE_EQUIPEMENT usage

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -60,7 +60,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAjoutes">
-            <td>{{ numeriqueEquipmentLabels[equipement.equipement as string] }}</td>
+            <td>{{ numeriqueEquipmentLabels[equipement.equipement as NUMERIQUE_EQUIPEMENT] }}</td>
             <td>{{ equipement.nombre }}</td>
             <td>{{ equipement.dureeAmortissement }}</td>
             <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
@@ -85,7 +85,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let equipement of equipementsAnciens">
-            <td>{{ numeriqueEquipmentLabels[equipement.equipement as string] }}</td>
+            <td>{{ numeriqueEquipmentLabels[equipement.equipement as NUMERIQUE_EQUIPEMENT] }}</td>
             <td>{{ equipement.nombre }}</td>
             <td>{{ equipement.dureeAmortissement }}</td>
             <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -44,6 +44,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   });
 
   numeriqueEquipmentLabels = NumeriqueEquipmentLabels;
+  NUMERIQUE_EQUIPEMENT = NUMERIQUE_EQUIPEMENT;
 
   equipementsAjoutes: EquipementNumerique[] = [];
   equipementsAnciens: EquipementNumerique[] = [];


### PR DESCRIPTION
## Summary
- expose `NUMERIQUE_EQUIPEMENT` enum to numerique component template
- use the enum type when indexing `numeriqueEquipmentLabels`

## Testing
- `npx ng build` *(fails: 403 Forbidden when trying to fetch ng)*

------
https://chatgpt.com/codex/tasks/task_e_6841a90c20508332beeb851a72bcad0d