### PR TITLE
Add mobilier support to batiment tab

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -66,7 +66,7 @@
     <button (click)="ajouterBatiment()">Ajouter ce bâtiment</button>
   </details>
 
-  <div *ngIf="batimentsAjoutes.length > 0">
+  <div *ngIf="batimentOnglet.batiments.length > 0">
     <h3>Liste des bâtiments saisis</h3>
     <table class="data-table">
       <thead>
@@ -83,7 +83,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let bat of batimentsAjoutes; let i = index">
+        <tr *ngFor="let bat of batimentOnglet.batiments; let i = index">
           <td>{{ bat.nom_ou_adresse }}</td>
           <td>{{ bat.dateConstruction }}</td>
           <td>{{ bat.dateDerniereGrosseRenovation }}</td>
@@ -141,7 +141,7 @@
     <button (click)="ajouterEntretien()">Ajouter cette rénovation</button>
   </details>
 
-  <div *ngIf="renovationsCourantes.length > 0">
+  <div *ngIf="batimentOnglet.entretiens.length > 0">
     <h3>Liste des entretiens et rénovations saisis</h3>
     <table class="data-table">
       <thead>
@@ -156,7 +156,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let reno of renovationsCourantes; let i = index">
+        <tr *ngFor="let reno of batimentOnglet.entretiens; let i = index">
           <td>{{ reno.nom_adresse }}</td>
           <td>{{ getLibelleTypeTravaux(reno.typeTravaux) }}</td>
           <td>{{ reno.dateTravaux }}</td>
@@ -200,7 +200,7 @@
     <button (click)="ajouterMobilier()">Ajouter ce mobilier</button>
   </details>
 
-  <div *ngIf="mobiliersAjoutes.length > 0">
+  <div *ngIf="batimentOnglet.mobiliers.length > 0">
     <h3>Liste du mobilier saisi</h3>
     <table class="data-table">
       <thead>
@@ -213,7 +213,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let mobilier of mobiliersAjoutes; let i = index">
+        <tr *ngFor="let mobilier of batimentOnglet.mobiliers; let i = index">
           <td>{{ getLibelleTypeMobilier(mobilier.mobilier) }}</td>
           <td>{{ mobilier.quantite }}</td>
           <td>{{ mobilier.poidsDuProduit }}</td>
@@ -227,4 +227,4 @@
   </div>
   <hr />
 </div>
-<app-save-footer [path]="'batimentsOnglet'"></app-save-footer>
+<app-save-footer [path]="'batimentsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@angular/core';
+import { BatimentOngletModel, BatimentExistantOuNeufConstruit, EntretienCourant, MobilierElectromenager } from '../../../models/batiment.model';
+import { EnumBatiment_TypeBatiment, EnumBatiment_TypeStructure, EnumBatiment_TypeTravaux, EnumBatiment_TypeMobilier } from '../../../models/bat.enum';
+
+@Injectable({ providedIn: 'root' })
+export class BatimentOngletMapperService {
+  fromDto(dto: any): BatimentOngletModel {
+    const batiments: BatimentExistantOuNeufConstruit[] = (dto.batimentsExistantOuNeufConstruits || []).map((b: any) => ({
+      id: b.id,
+      nom_ou_adresse: b.nom_ou_adresse ?? '',
+      dateConstruction: b.dateConstruction ?? null,
+      moinsDe50ans: b.moinsDe50ans ?? null,
+      renoComplete: b.renoComplete ?? null,
+      dateDerniereGrosseRenovation: b.dateDerniereGrosseRenovation ?? null,
+      acvBatimentRealisee: b.acvBatimentRealisee ?? null,
+      emissionsGesReellesTCO2: b.emissionsGesReellesTCO2 ?? null,
+      typeBatiment: b.typeBatiment as EnumBatiment_TypeBatiment,
+      surfaceEnM2: b.surfaceEnM2 ?? null,
+      typeStructure: b.typeStructure as EnumBatiment_TypeStructure,
+      dateAjoutEnBase: b.dateAjoutEnBase ?? null,
+    }));
+
+    const entretiens: EntretienCourant[] = (dto.entretiensCourants || []).map((e: any) => ({
+      id: e.id,
+      dateAjout: e.dateAjout ?? null,
+      nom_adresse: e.nom_adresse ?? '',
+      typeTravaux: e.typeTravaux as EnumBatiment_TypeTravaux,
+      dateTravaux: e.dateTravaux ?? null,
+      typeBatiment: e.typeBatiment as EnumBatiment_TypeBatiment,
+      surfaceConcernee: e.surfaceConcernee ?? null,
+      dureeAmortissement: e.dureeAmortissement ?? null,
+    }));
+
+    const mobiliers: MobilierElectromenager[] = (dto.mobiliers || []).map((m: any) => ({
+      id: m.id,
+      dateAjout: m.dateAjout ?? null,
+      mobilier: m.mobilier as EnumBatiment_TypeMobilier,
+      quantite: m.quantite ?? null,
+      poidsDuProduit: m.poidsDuProduit ?? null,
+      dureeAmortissement: m.dureeAmortissement ?? null,
+    }));
+
+    return {
+      estTermine: dto.estTermine,
+      note: dto.note,
+      batiments,
+      entretiens,
+      mobiliers,
+    };
+  }
+
+  toDto(model: BatimentOngletModel): any {
+    return {
+      estTermine: model.estTermine,
+      note: model.note,
+      batimentsExistantOuNeufConstruits: model.batiments.map((b: BatimentExistantOuNeufConstruit) => ({
+        id: b.id,
+        nom_ou_adresse: b.nom_ou_adresse,
+        dateConstruction: b.dateConstruction,
+        moinsDe50ans: b.moinsDe50ans,
+        renoComplete: b.renoComplete,
+        dateDerniereGrosseRenovation: b.dateDerniereGrosseRenovation,
+        acvBatimentRealisee: b.acvBatimentRealisee,
+        emissionsGesReellesTCO2: b.emissionsGesReellesTCO2,
+        typeBatiment: typeof b.typeBatiment === 'string' ? b.typeBatiment : (b.typeBatiment as EnumBatiment_TypeBatiment).toString(),
+        surfaceEnM2: b.surfaceEnM2,
+        typeStructure: typeof b.typeStructure === 'string' ? b.typeStructure : (b.typeStructure as EnumBatiment_TypeStructure).toString(),
+        dateAjoutEnBase: b.dateAjoutEnBase,
+      })),
+      entretiensCourants: model.entretiens.map((e: EntretienCourant) => ({
+        id: e.id,
+        dateAjout: e.dateAjout,
+        nom_adresse: e.nom_adresse,
+        typeTravaux: typeof e.typeTravaux === 'string' ? e.typeTravaux : (e.typeTravaux as EnumBatiment_TypeTravaux).toString(),
+        dateTravaux: e.dateTravaux,
+        typeBatiment: typeof e.typeBatiment === 'string' ? e.typeBatiment : (e.typeBatiment as EnumBatiment_TypeBatiment).toString(),
+        surfaceConcernee: e.surfaceConcernee,
+        dureeAmortissement: e.dureeAmortissement,
+      })),
+      mobiliers: model.mobiliers.map((m: MobilierElectromenager) => ({
+        id: m.id,
+        dateAjout: m.dateAjout,
+        mobilier: typeof m.mobilier === 'string' ? m.mobilier : (m.mobilier as EnumBatiment_TypeMobilier).toString(),
+        quantite: m.quantite,
+        poidsDuProduit: m.poidsDuProduit,
+        dureeAmortissement: m.dureeAmortissement,
+      })),
+    };
+  }
+}

--- a/frontend/src/app/models/batiment.model.ts
+++ b/frontend/src/app/models/batiment.model.ts
@@ -1,0 +1,44 @@
+import { EnumBatiment_TypeBatiment, EnumBatiment_TypeStructure, EnumBatiment_TypeTravaux, EnumBatiment_TypeMobilier } from './bat.enum';
+
+export interface BatimentExistantOuNeufConstruit {
+  id?: number;
+  nom_ou_adresse: string;
+  dateConstruction: string | null;
+  moinsDe50ans: boolean | null;
+  renoComplete: boolean | null;
+  dateDerniereGrosseRenovation: string | null;
+  acvBatimentRealisee: boolean | null;
+  emissionsGesReellesTCO2: number | null;
+  typeBatiment: EnumBatiment_TypeBatiment | string;
+  surfaceEnM2: number | null;
+  typeStructure: EnumBatiment_TypeStructure | string;
+  dateAjoutEnBase?: string | null;
+}
+
+export interface EntretienCourant {
+  id?: number;
+  dateAjout: string | null;
+  nom_adresse: string;
+  typeTravaux: EnumBatiment_TypeTravaux | string;
+  dateTravaux: string | null;
+  typeBatiment: EnumBatiment_TypeBatiment | string;
+  surfaceConcernee: number | null;
+  dureeAmortissement: number | null;
+}
+
+export interface MobilierElectromenager {
+  id?: number;
+  dateAjout: string | null;
+  mobilier: EnumBatiment_TypeMobilier | string;
+  quantite: number | null;
+  poidsDuProduit: number | null;
+  dureeAmortissement: number | null;
+}
+
+export interface BatimentOngletModel {
+  estTermine?: boolean;
+  note?: string;
+  batiments: BatimentExistantOuNeufConstruit[];
+  entretiens: EntretienCourant[];
+  mobiliers: MobilierElectromenager[];
+}

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -70,6 +70,7 @@ BatimentsOnglet: {
 
   ajouterMobilier: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}/mobilierElectromenager`,
   supprimerMobilier: (tabId: string, mobilierId: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${tabId}/mobilierElectromenager/${mobilierId}`,
+  update: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}`
 },
 AutoOnglet: {
   getById: (id: string) => `${BASE_URL}/vehiculeOnglet/${id}`,


### PR DESCRIPTION
## Summary
- define batiment immobilisation models
- map batiment DTOs with new mapper service
- add update endpoint for batiments
- connect mobilier data to endpoints and save footer

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc --noEmit` *(fails: cannot find angular modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab10f9648332b25be755d9d30f32