### PR TITLE
Fix mobiliers fallback

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
@@ -31,7 +31,8 @@ export class BatimentOngletMapperService {
       dureeAmortissement: e.dureeAmortissement ?? null,
     }));
 
-    const mobiliers: MobilierElectromenager[] = (dto.mobiliers || []).map((m: any) => ({
+    const mobilierDtoList = dto.mobiliers ?? dto.mobilierElectromenagerList;
+    const mobiliers: MobilierElectromenager[] = (mobilierDtoList || []).map((m: any) => ({
       id: m.id,
       dateAjout: m.dateAjout ?? null,
       mobilier: m.mobilier as EnumBatiment_TypeMobilier,
@@ -77,7 +78,7 @@ export class BatimentOngletMapperService {
         surfaceConcernee: e.surfaceConcernee,
         dureeAmortissement: e.dureeAmortissement,
       })),
-      mobiliers: model.mobiliers.map((m: MobilierElectromenager) => ({
+      mobilierElectromenagerList: model.mobiliers.map((m: MobilierElectromenager) => ({
         id: m.id,
         dateAjout: m.dateAjout,
         mobilier: typeof m.mobilier === 'string' ? m.mobilier : (m.mobilier as EnumBatiment_TypeMobilier).toString(),


### PR DESCRIPTION
## Summary
- use fallback for mobiliers when mapping from DTOs
- send mobilierElectromenagerList when mapping to DTO

## Testing
- `npx ng build` *(fails: 403 Forbidden)*
- `npm start` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b57fca0883328e8686adcfbefea8