### PR TITLE
Fix dashboard redirects

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -14,20 +14,20 @@ import { OngletStatusService } from '../../services/onglet-status.service';
 export class DashboardComponent {
   currentYear: number = 2024;
 
-  onglets = [
-    { label: 'Energie', status: false, path: 'energieOnglet' },
-    { label: 'Emissions fugitives', status: true, path: 'emissionsFugitivesOnglet' },
-    { label: 'Mobilité dom-trav', status: true, path: 'mobiliteDomTravOnglet' },
-    { label: 'Autre mob fr', status: false, path: 'autreMobFrOnglet' },
-    { label: 'Mob internatio', status: false, path: 'mobiliteInternationaleOnglet' },
-    { label: 'Bâtiments', status: true, path: 'batimentsOnglet' },
-    { label: 'Parkings', status: true, path: 'parkingsOnglet' },
-    { label: 'Auto', status: true, path: 'autoOnglet' },
-    { label: 'Numérique', status: true, path: 'numeriqueOnglet' },
-    { label: 'Autres immob', status: false, path: 'immobOnglet' },
-    { label: 'Achats', status: false, path: 'achatsOnglet' },
-    { label: 'Déchets', status: true, path: 'dechetsOnglet' }
-  ];
+    onglets = [
+      { label: 'Energie', status: false, path: 'energieOnglet' },
+      { label: 'Emissions fugitives', status: true, path: 'emissionFugitiveOnglet' },
+      { label: 'Mobilité dom-trav', status: true, path: 'mobiliteDomicileTravailOnglet' },
+      { label: 'Autre mob fr', status: false, path: 'autreMobFrOnglet' },
+      { label: 'Mob internatio', status: false, path: 'mobInternationalOnglet' },
+      { label: 'Bâtiments', status: true, path: 'batimentImmobilisationMobilierOnglet' },
+      { label: 'Parkings', status: true, path: 'parkingVoirieOnglet' },
+      { label: 'Auto', status: true, path: 'vehiculeOnglet' },
+      { label: 'Numérique', status: true, path: 'numeriqueOnglet' },
+      { label: 'Autres immob', status: false, path: 'autreImmobilisationOnglet' },
+      { label: 'Achats', status: false, path: 'achatOnglet' },
+      { label: 'Déchets', status: true, path: 'dechetOnglet' }
+    ];
 
   constructor(private router: Router, private statusService: OngletStatusService) {}
 


### PR DESCRIPTION
## Summary
- correct dashboard path names used for routing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b8541c108332bda5b755324254d4