### PR TITLE
Uniform page background across data entry tabs

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.scss
@@ -1,4 +1,6 @@
 .main-container {
+  background-color: #E6F0FF;
+  min-height: 100vh;
   padding: 20px;
   font-family: Arial, sans-serif;
 }

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.scss
@@ -1,5 +1,6 @@
 .main-container {
   background-color: #E6F0FF;
+  min-height: 100vh;
   width: 100%;
   padding: 2rem;
   box-sizing: border-box;

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.scss
@@ -1,4 +1,6 @@
 .main-container {
+  background-color: #E6F0FF;
+  min-height: 100vh;
   width: 100%;
   padding: 2rem;
   box-sizing: border-box;

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
@@ -1,4 +1,6 @@
 .main-container {
+  background-color: #E6F0FF;
+  min-height: 100vh;
   width: 100%;
   padding: 2rem;
   box-sizing: border-box;

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
@@ -1,7 +1,8 @@
 .main-container {
+  background-color: #E6F0FF;
+  min-height: 100vh;
   padding: 20px;
   font-family: Arial, sans-serif;
-  background-color: #f9f9f9;
   border-radius: 6px;
   max-width: 800px;
   margin: auto;

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.scss
@@ -1,4 +1,6 @@
 .main-container {
+  background-color: #E6F0FF;
+  min-height: 100vh;
   width: 100%;
   padding: 2rem;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- apply the Energie page layout to other data entry tabs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842baa5a0848332a006672b8d5b0e60