### PR TITLE
Add loader to header save button

### DIFF
--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
@@ -7,7 +7,8 @@
     <span class="year-label">Année : {{ currentYear - 1 }} - {{ currentYear }}</span>
 
     <!-- Bouton Sauvegarder -->
-    <button class="button primary-button">Sauvegarder</button>
+    <button class="button primary-button" (click)="save()" [disabled]="loading">Sauvegarder</button>
+    <div class="loader" *ngIf="loading"></div>
 
     <!-- Trait séparateur -->
     <div class="splitter"><br class="splitter"></div>

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.scss
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.scss
@@ -159,3 +159,18 @@ body {
   cursor: not-allowed;
   opacity: 0.5;
 }
+
+.loader {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #1976d2;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  margin-left: 1rem;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -44,6 +44,8 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
   selectedYear: number;
   years: YearRange[] = [];
 
+  loading = false;
+
   @ViewChild('tabsContainer') tabsContainer!: ElementRef<HTMLDivElement>;
   @ViewChild('tabsElement') tabsRef!: ElementRef<HTMLDivElement>; // nom changé
   @ViewChildren('tabBtn') tabButtons!: QueryList<ElementRef<HTMLButtonElement>>;
@@ -114,6 +116,13 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
     if (this.startIndex + this.visibleCount < this.tabs.length) {
       this.startIndex++;
     }
+  }
+
+  save() {
+    this.loading = true;
+    setTimeout(() => {
+      this.loading = false;
+    }, 2000);
   }
 
   navigateTo(tab: string) {


### PR DESCRIPTION
## Summary
- show loading spinner when saving from header
- style loader in header component

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb13a2d48332863314c05f1b5c67