### PR TITLE
Fix help icon

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -2,7 +2,13 @@
   <div class="left-panel">
     <div class="page-title">
       <h2>Mobilité internationale</h2>
-      <span class="help-icon" title="Lorem ipsum"><i class="fa-solid fa-circle-info"></i></span>
+      <span class="help-icon" title="Lorem ipsum">
+        <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"></circle>
+          <rect x="11" y="10" width="2" height="6" fill="currentColor"></rect>
+          <circle cx="12" cy="8" r="1" fill="currentColor"></circle>
+        </svg>
+      </span>
     </div>
 
     <details>


### PR DESCRIPTION
## Summary
- replace Font Awesome help icon with inline SVG so it is visible when external styles are unavailable

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7dd92c88332bd2a4122b8bbfb5f