### PR TITLE
Fix help icon alignment

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -1,12 +1,14 @@
 <div class="main-container">
-  <h2>Achats</h2>
-  <span class="help-icon" title="Lorem ipsum">
+  <div class="page-title">
+    <h2>Achats</h2>
+    <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
-  </span>
+    </span>
+  </div>
   <div class="left-panel">
     <h2>Poste consommable</h2>
     <table class="data-table">

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Poste automobile</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Poste automobile</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <details>
       <summary><strong>Saisir une nouvelle voiture</strong></summary>
 

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Autres immobilisations</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Autres immobilisations</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <p class="question-title">Avez-vous des panneaux photovoltaïques ?</p>
     <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="true"/> Oui</label>
     <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="false"/> Non</label>

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Autre mobilité en France</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Autre mobilité en France</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <!-- Section 1 : Parc immobilier -->
-  <h2>Parc immobilier</h2>
-  <span class="help-icon" title="Lorem ipsum">
+  <div class="page-title">
+    <h2>Parc immobilier</h2>
+    <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
-  </span>
+    </span>
+  </div>
   <details>
     <summary><strong>Saisir un nouveau bâtiment</strong></summary>
 

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Déchets</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Déchets</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Mobilité domicile-travail</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Mobilité domicile-travail</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
 
     <table class="data-table">
       <thead>

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Émissions fugitives</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Émissions fugitives</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <div class="container">
       <!-- Message d'erreur -->
       <div *ngIf="hasError" class="no-data-message">

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Énergie</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Énergie</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <table class="data-table">
       <thead>
       <tr>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.scss
@@ -96,18 +96,6 @@ button {
   margin-top: 1rem;
 }
 
-.help-icon {
-  margin-left: 0.5rem;
-  cursor: pointer;
-  color: #000;
-  margin-bottom: .75rem;
-  font-size: larger;
-}
-
-.page-title {
-  display: flex;
-  align-items: center;
-}
 
 details {
   background-color: #f9f9f9;

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Poste numérique</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Poste numérique</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <p class="question-title">Disposez-vous de données sur le cloud ?</p>
     <label><input type="radio" name="hasCloud" [(ngModel)]="donneesCloudDisponibles" [value]="true"
                   (change)="updateData()"/> Oui</label>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -1,13 +1,15 @@
 <div class="main-container">
   <div class="left-panel">
-    <h2>Parkings</h2>
-    <span class="help-icon" title="Lorem ipsum">
+    <div class="page-title">
+      <h2>Parkings</h2>
+      <span class="help-icon" title="Lorem ipsum">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="black"></circle>
           <rect x="11" y="10" width="2" height="6" fill="white"></rect>
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
+    </div>
     <details>
       <summary><strong>Saisir un nouveau parking</strong></summary>
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -51,3 +51,16 @@ button {
 td{
   background-color: white;
 }
+
+.help-icon {
+  margin-left: 0.5rem;
+  cursor: pointer;
+  color: #000;
+  margin-bottom: 0.75rem;
+  font-size: larger;
+}
+
+.page-title {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- align help icons with headings across pages
- add global styles for help icon and page-title
- remove duplicate icon styles

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842cbb70acc8332a09842c45201c9f3