### PR TITLE
Load onglet status on dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -49,6 +49,7 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadOngletIds();
+    this.loadOngletStatuses();
   }
 
   loadOngletIds(): void {
@@ -58,6 +59,17 @@ export class DashboardComponent implements OnInit {
       },
       error: (err) => {
         console.error('Erreur récupération onglet IDs:', err);
+      }
+    });
+  }
+
+  loadOngletStatuses(): void {
+    this.ongletService.getOngletStatuses(this.entiteId, this.currentYear)?.subscribe({
+      next: (statuses) => {
+        this.statusService.setStatuses(statuses);
+      },
+      error: (err) => {
+        console.error('Erreur récupération statuses:', err);
       }
     });
   }

--- a/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
+++ b/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
@@ -22,4 +22,17 @@ export class OngletService {
     const url = `${ApiEndpoints.Onglets.getAllIds(entiteId)}?annee=${annee}`;
     return this.http.get<{ [key: string]: number }>(url, { headers });
   }
+
+  getOngletStatuses(entiteId: number, annee: number) {
+    const token = this.auth.getToken();
+    if (!token) return;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+
+    const url = `${ApiEndpoints.Onglets.getAllStatus(entiteId)}?annee=${annee}`;
+    return this.http.get<{ [key: string]: boolean }>(url, { headers });
+  }
 }

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -2,7 +2,8 @@ const BASE_URL = 'http://localhost:8080';
 
 export const ApiEndpoints = {
   Onglets: {
-    getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`
+    getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`,
+    getAllStatus: (entiteId: number) => `${BASE_URL}/general/${entiteId}/status`
   },
 
   EnergieOnglet: {

--- a/frontend/src/app/services/onglet-status.service.ts
+++ b/frontend/src/app/services/onglet-status.service.ts
@@ -11,6 +11,11 @@ export class OngletStatusService {
     this.statuses.next({ ...current, [path]: status });
   }
 
+  setStatuses(newStatuses: Record<string, boolean>): void {
+    const current = this.statuses.getValue();
+    this.statuses.next({ ...current, ...newStatuses });
+  }
+
   getStatus(path: string): boolean {
     return this.statuses.getValue()[path] ?? false;
   }


### PR DESCRIPTION
## Summary
- fetch onglet completion status when loading the dashboard
- expose GET endpoint for onglet statuses
- allow setting multiple statuses in `OngletStatusService`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d250b91883329d475bb236b8cf2e