### PR TITLE
Fix onglet status endpoint path

### DIFF
--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -3,7 +3,7 @@ const BASE_URL = 'http://localhost:8080';
 export const ApiEndpoints = {
   Onglets: {
     getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`,
-    getAllStatus: (entiteId: number) => `${BASE_URL}/general/${entiteId}/status`
+    getAllStatus: (entiteId: number) => `${BASE_URL}/general/status/${entiteId}`
   },
 
   EnergieOnglet: {


### PR DESCRIPTION
## Summary
- update `ApiEndpoints.Onglets.getAllStatus` path to match backend

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f2004ba88332ac38378f84f4968b