### PR TITLE
Connect numerique tab to backend

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
@@ -12,7 +12,8 @@ export class NumeriqueOngletMapperService {
 
   fromDto(dto: any): NumeriqueModel {
     const equipements: EquipementNumerique[] = (dto.equipementNumeriqueList || []).map((e: any) => ({
-      equipement: this.normalizeEquipement(e.equipement) as NUMERIQUE_EQUIPEMENT,
+      id: e.id,
+      equipement: this.normalizeEquipement(e.equipement ?? e.type) as NUMERIQUE_EQUIPEMENT,
       nombre: e.nombre ?? null,
       dureeAmortissement: e.dureeAmortissement ?? null,
       emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues ?? false,
@@ -40,12 +41,24 @@ export class NumeriqueOngletMapperService {
       TraficTipUtilisateur: model.tipUtilisateur,
       PartTraficFranceEtranger: model.partTraficFranceEtranger,
       equipementNumeriqueList: model.equipements.map((e: EquipementNumerique) => ({
+        id: e.id,
         type: typeof e.equipement === 'string' ? e.equipement : (e.equipement as NUMERIQUE_EQUIPEMENT).toString(),
         nombre: e.nombre,
         dureeAmortissement: e.dureeAmortissement,
         emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues,
         emissionsReellesParProduitKgCO2e: e.emissionsReellesParProduitKgCO2e,
       })),
+    };
+  }
+
+  toEquipementDto(e: EquipementNumerique): any {
+    return {
+      id: e.id,
+      type: typeof e.equipement === 'string' ? e.equipement : (e.equipement as NUMERIQUE_EQUIPEMENT).toString(),
+      nombre: e.nombre,
+      dureeAmortissement: e.dureeAmortissement,
+      emissionsGesPrecisesConnues: e.emissionsGesPrecisesConnues,
+      emissionsReellesParProduitKgCO2e: e.emissionsReellesParProduitKgCO2e,
     };
   }
 }

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -57,29 +57,6 @@
       <button type="button" (click)="ajouterEquipement()">Ajouter cet équipement</button>
     </details>
 
-    <div *ngIf="equipementsAjoutes.length > 0">
-      <h3>Équipements numériques ajoutés</h3>
-      <table class="data-table">
-        <thead>
-        <tr>
-          <th>Type</th>
-          <th>Quantité</th>
-          <th>Amortissement</th>
-          <th>GES Connus</th>
-          <th>GES Réels</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let equipement of equipementsAjoutes">
-          <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
-          <td>{{ equipement.nombre }}</td>
-          <td>{{ equipement.dureeAmortissement }}</td>
-          <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
-          <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
 
     <div *ngIf="equipementsAnciens.length > 0">
       <h3>Équipements enregistrés les années précédentes</h3>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -1,13 +1,13 @@
 import {Component, OnInit, inject} from '@angular/core';
-import {HttpClient, HttpClientModule} from '@angular/common/http';
+import {HttpClientModule} from '@angular/common/http';
 import {ActivatedRoute} from '@angular/router';
 import {FormsModule} from '@angular/forms';
 import {AuthService} from '../../../services/auth.service';
-import {ApiEndpoints} from '../../../services/api-endpoints';
 import {CommonModule} from '@angular/common';
 import {SaveFooterComponent} from '../../save-footer/save-footer.component';
 import {OngletStatusService} from '../../../services/onglet-status.service';
 import {NumeriqueOngletMapperService} from './numerique-onglet-mapper.service';
+import {NumeriqueService} from './numerique.service';
 import {EquipementNumerique, NumeriqueModel} from '../../../models/numerique.model';
 import {NUMERIQUE_EQUIPEMENT} from '../../../models/enums/numerique.enum';
 import {numeriqueEquipmentLabels} from '../../../models/numerique-equipment-labels';
@@ -20,7 +20,7 @@ import {numeriqueEquipmentLabels} from '../../../models/numerique-equipment-labe
   imports: [FormsModule, HttpClientModule, CommonModule, SaveFooterComponent]
 })
 export class NumeriqueSaisieDonneesPageComponent implements OnInit {
-  private http = inject(HttpClient);
+  private numeriqueService = inject(NumeriqueService);
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
   private statusService = inject(OngletStatusService);
@@ -47,7 +47,6 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   numeriqueEquipmentLabels = numeriqueEquipmentLabels;
   NUMERIQUE_EQUIPEMENT = NUMERIQUE_EQUIPEMENT;
 
-  equipementsAjoutes: EquipementNumerique[] = [];
   equipementsAnciens: EquipementNumerique[] = [];
   estTermine = false;
 
@@ -79,7 +78,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
       'Authorization': `Bearer ${token}`
     };
 
-    this.http.get<any>(ApiEndpoints.NumeriqueOnglet.getById(id), {headers}).subscribe({
+    this.numeriqueService.getOnglet(id, headers).subscribe({
       next: data => {
         const model = this.mapper.fromDto(data);
         this.donneesCloudDisponibles = model.cloudDataDisponible;
@@ -98,15 +97,25 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
       this.nouvelEquipement.dureeAmortissement !== null &&
       (!this.nouvelEquipement.emissionsGesPrecisesConnues || this.nouvelEquipement.emissionsReellesParProduitKgCO2e !== null)
     ) {
-      this.equipementsAjoutes.push({...this.nouvelEquipement});
+      const id = this.route.snapshot.paramMap.get('id');
+      const token = this.authService.getToken();
+      if (!id || !token) return;
+      const headers = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      };
+      const dto = this.mapper.toEquipementDto(this.nouvelEquipement);
+      this.numeriqueService.addEquipement(id, dto, headers).subscribe({
+        next: () => this.loadData(id),
+        error: err => console.error('Erreur ajout équipement', err)
+      });
       this.nouvelEquipement = {
         equipement: NUMERIQUE_EQUIPEMENT.ECRAN,
         nombre: null,
         dureeAmortissement: null,
-        emissionsGesPrecisesConnues: true,
+        emissionsGesPrecisesConnues: false,
         emissionsReellesParProduitKgCO2e: null
       };
-      this.updateData();
     }
   }
 
@@ -129,12 +138,11 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
       traficCloud: this.traficCloud,
       tipUtilisateur: this.tipUtilisateur,
       partTraficFranceEtranger: this.partTraficFranceEtranger,
-      equipements: this.equipementsAjoutes
+      equipements: []
     };
 
     const payload = this.mapper.toDto(model);
-    console.log(payload);
-    this.http.patch(ApiEndpoints.NumeriqueOnglet.update(id), payload, {headers}).subscribe({
+    this.numeriqueService.updateOnglet(id, payload, headers).subscribe({
       error: err => console.error('Erreur lors de la mise à jour des données numériques', err)
     });
   }

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiEndpoints } from '../../../services/api-endpoints';
+
+@Injectable({ providedIn: 'root' })
+export class NumeriqueService {
+  constructor(private http: HttpClient) {}
+
+  getOnglet(id: string, headers: any): Observable<any> {
+    return this.http.get<any>(ApiEndpoints.NumeriqueOnglet.getById(id), { headers });
+  }
+
+  updateOnglet(id: string, payload: any, headers: any): Observable<any> {
+    return this.http.patch<any>(ApiEndpoints.NumeriqueOnglet.update(id), payload, { headers });
+  }
+
+  addEquipement(id: string, equipement: any, headers: any): Observable<any> {
+    return this.http.post<any>(ApiEndpoints.NumeriqueOnglet.addEquipement(id), equipement, { headers });
+  }
+
+  deleteEquipement(id: string, equipId: string, headers: any): Observable<any> {
+    return this.http.delete<any>(ApiEndpoints.NumeriqueOnglet.deleteEquipement(id, equipId), { headers });
+  }
+
+  updateEquipement(id: string, equipId: string, equipement: any, headers: any): Observable<any> {
+    return this.http.patch<any>(ApiEndpoints.NumeriqueOnglet.updateEquipement(id, equipId), equipement, { headers });
+  }
+
+  getResult(id: string, headers: any): Observable<any> {
+    return this.http.get<any>(ApiEndpoints.NumeriqueOnglet.getResult(id), { headers });
+  }
+}

--- a/frontend/src/app/models/numerique.model.ts
+++ b/frontend/src/app/models/numerique.model.ts
@@ -1,6 +1,7 @@
 import {NUMERIQUE_EQUIPEMENT} from './enums/numerique.enum';
 
 export interface EquipementNumerique {
+  id?: number;
   equipement: NUMERIQUE_EQUIPEMENT;
   nombre: number | null;
   dureeAmortissement: number | null;

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -45,7 +45,13 @@ ImmobOnglet: {
 },
 NumeriqueOnglet: {
   getById: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}`
+  update: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}`,
+  addEquipement: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}/equipementNumerique`,
+  deleteEquipement: (ongletId: string, equipId: string) =>
+    `${BASE_URL}/numeriqueOnglet/${ongletId}/equipementNumerique/${equipId}`,
+  updateEquipement: (ongletId: string, equipId: string) =>
+    `${BASE_URL}/numeriqueOnglet/${ongletId}/equipementNumerique/${equipId}`,
+  getResult: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}/resultat`
 },
 ParkingVoirieOnglet: {
   getById: (id: string) => `${BASE_URL}/parkingVoirieOnglet/${id}`,


### PR DESCRIPTION
## Summary
- track numerique equipment IDs in model
- map equipment IDs and convert enum names both ways
- add service for numerique onglet API calls
- use NumeriqueService from numerique page and remove local list
- expose numerique equipment endpoints in `api-endpoints.ts`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8d473d848332a9f77f93308b9a02