### PR TITLE
Fix dashboard edit icons

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -26,7 +26,7 @@
           {{ getStatus(onglet.path) ? '✅' : '❌' }}
         </span>
         {{ onglet.label }}
-        <span class="edit" (click)="goToSaisie(onglet.path)">✏️</span>
+        <a class="edit" [routerLink]="['/', onglet.path, ongletIdMap[onglet.path]]">✏️</a>
       </div>
     </div>
     <div class="column">
@@ -35,7 +35,7 @@
           {{ getStatus(onglet.path) ? '✅' : '❌' }}
         </span>
         {{ onglet.label }}
-        <span class="edit" (click)="goToSaisie(onglet.path)">✏️</span>
+        <a class="edit" [routerLink]="['/', onglet.path, ongletIdMap[onglet.path]]">✏️</a>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { OngletStatusService } from '../../services/onglet-status.service';
@@ -12,7 +12,7 @@ import { Subscription } from 'rxjs';
   standalone: true,
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [CommonModule, FormsModule]
+  imports: [CommonModule, FormsModule, RouterModule]
 })
 
 export class DashboardComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## Summary
- import `RouterModule` in the dashboard component
- use `routerLink` for edit icons so that all categories redirect properly

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b91fd87a88332a1024f8815a9ed0e