### PR TITLE
Connect footer completion to dashboard status

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -67,6 +67,7 @@ export class DashboardComponent {
     this.selectedYear = this.yearService.getSelectedYear();
 
     this.loadOngletIds();
+    this.loadOngletStatuses();
   }
 
   getStatus(path: string): boolean {
@@ -104,6 +105,7 @@ export class DashboardComponent {
     this.selectedYear = newYear;
     this.yearService.setSelectedYear(newYear);
     this.loadOngletIds();
+    this.loadOngletStatuses();
   }
 
   loadOngletIds(): void {
@@ -113,6 +115,17 @@ export class DashboardComponent {
       },
       error: (err) => {
         console.error('Erreur récupération onglet IDs:', err);
+      }
+    });
+  }
+
+  loadOngletStatuses(): void {
+    this.ongletService.getOngletStatuses(this.entiteId, this.selectedYear)?.subscribe({
+      next: (result) => {
+        this.statusService.setStatuses(result);
+      },
+      error: (err) => {
+        console.error('Erreur récupération statut onglets:', err);
       }
     });
   }

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
@@ -119,6 +119,7 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
       next: data => {
         this.items = this.mapper.fromDto(data);
         this.estTermine = this.items.estTermine ?? false;
+        this.statusService.setStatus('achatsOnglet', this.estTermine);
       },
       error: err => console.error("Erreur de chargement", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -58,5 +58,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'vehiculeOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'autoOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
@@ -72,6 +72,8 @@ export class AutoSaisieDonneesPageComponent implements OnInit {
         const model = this.mapper.fromDto(data);
         this.vehiculeOnglet.vehicules = model.vehicules;
         this.vehiculeOnglet.note = model.note;
+        this.vehiculeOnglet.estTermine = model.estTermine ?? false;
+        this.statusService.setStatus('autoOnglet', this.vehiculeOnglet.estTermine);
       },
       error: err => console.error('Erreur lors du chargement des véhicules', err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -65,9 +65,9 @@ export class AutreImmobilisationPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('autreImmobilisationOnglet');
+    this.estTermine = this.statusService.getStatus('immobOnglet');
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['autreImmobilisationOnglet'] ?? false;
+      this.estTermine = s['immobOnglet'] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
@@ -93,12 +93,14 @@ export class AutreImmobilisationPageComponent implements OnInit {
     this.http.get<any>(ApiEndpoints.ImmobOnglet.getById(id), { headers }).subscribe(
       (data) => {
         this.items = { ...this.items, ...data };
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('immobOnglet', this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);
       }
     );
-  }  
+  }
 
   ajouterMachine() {
     this.items.machines.push({

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
@@ -54,7 +54,11 @@ export class AutreMobSaisieDonneesPageComponent implements OnInit {
     };
 
     this.http.get<any>(ApiEndpoints.AutreMobFrOnglet.getById(id), { headers }).subscribe({
-      next: data => (this.items = this.mapper.parseFlatData(data)),
+      next: data => {
+        this.items = this.mapper.parseFlatData(data);
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('autreMobFrOnglet', this.estTermine);
+      },
       error: err => console.error('Erreur chargement autre mob:', err),
     });
   }

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -253,5 +253,5 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     </table>
   </div>
   <hr/>
-  <app-save-footer [path]="'batimentImmobilisationMobilierOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'batimentsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
@@ -197,6 +197,8 @@ export class BatimentsSaisieDonneesPageComponent implements OnInit {
       next: (data) => {
         const model = this.mapper.fromDto(data);
         this.batimentOnglet = model;
+        this.batimentOnglet.estTermine = model.estTermine ?? false;
+        this.statusService.setStatus('batimentsOnglet', this.batimentOnglet.estTermine);
       },
       error: (error) => {
         console.error('Erreur lors de la récupération des données :', error);

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -45,5 +45,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'dechetOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'dechetsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
@@ -34,9 +34,9 @@ export class DechetSaisieDonneesPageComponent implements OnInit {
   traitements = Object.values(TRAITEMENT_DECHET);
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('dechetOnglet');
+    this.estTermine = this.statusService.getStatus('dechetsOnglet');
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['dechetOnglet'] ?? false;
+      this.estTermine = s['dechetsOnglet'] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) this.loadData(id);
@@ -51,7 +51,11 @@ export class DechetSaisieDonneesPageComponent implements OnInit {
     };
 
     this.http.get<any>(ApiEndpoints.DechetsOnglet.getById(id), { headers }).subscribe({
-      next: data => this.items = this.mapper.parseData(data),
+      next: data => {
+        this.items = this.mapper.parseData(data);
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('dechetsOnglet', this.estTermine);
+      },
       error: err => console.error('Erreur chargement déchets:', err)
     });
   }

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -54,5 +54,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'mobiliteDomicileTravailOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'mobiliteDomTravOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
@@ -38,9 +38,9 @@ export class DomTravSaisieDonneesPageComponent implements OnInit {
 
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('mobiliteDomicileTravailOnglet');
+    this.estTermine = this.statusService.getStatus('mobiliteDomTravOnglet');
     this.statusService.statuses$.subscribe(s => {
-      this.estTermine = s['mobiliteDomicileTravailOnglet'] ?? false;
+      this.estTermine = s['mobiliteDomTravOnglet'] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) this.loadData(id);
@@ -63,6 +63,8 @@ export class DomTravSaisieDonneesPageComponent implements OnInit {
         this.items = this.mapper.parseFlatData(data);
         this.nbJoursEtudiant = data.nbJoursDeplacementEtudiant ?? 0;
         this.nbJoursSalarie = data.nbJoursDeplacementSalarie ?? 0;
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('mobiliteDomTravOnglet', this.estTermine);
       },
       error: (err) => console.error("Erreur lors du chargement des données", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -121,5 +121,5 @@
       </div>
     </div>
   </div>
-  <app-save-footer [path]="'emissionFugitiveOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'emissionsFugitivesOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
@@ -128,9 +128,9 @@ export class EmissFugiSaisieDonneesPageComponent implements OnInit {
   constructor(private emmissionsFugtivesService: EmmissionsFugtivesService) {}
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('emissionFugitiveOnglet');
+    this.estTermine = this.statusService.getStatus('emissionsFugitivesOnglet');
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['emissionFugitiveOnglet'] ?? false;
+      this.estTermine = s['emissionsFugitivesOnglet'] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       this.emmissionFugitiveOngletId = params.get('id') || '';
@@ -185,6 +185,8 @@ export class EmissFugiSaisieDonneesPageComponent implements OnInit {
 
         this.noData = this.machines.length === 0;
         this.hasError = false;
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('emissionsFugitivesOnglet', this.estTermine);
       },
       error: (err) => {
         console.error('Erreur API', err);

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
@@ -68,6 +68,8 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
           consoElecSpecifique: data.consoElecSpecifique,
           consoEau: data.consoEau
         };
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('energieOnglet', this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -63,6 +63,8 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
         if (data.destinations) {
           this.destinations = data.destinations;
         }
+        this.estTermine = data.estTermine ?? false;
+        this.statusService.setStatus('mobiliteInternationaleOnglet', this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -86,6 +86,8 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
         this.tipUtilisateur = model.tipUtilisateur;
         this.partTraficFranceEtranger = model.partTraficFranceEtranger;
         this.equipementsAnciens = model.equipements;
+        this.estTermine = model.estTermine ?? false;
+        this.statusService.setStatus('numeriqueOnglet', this.estTermine);
       },
       error: err => console.error("Erreur lors du chargement des données numériques", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -83,5 +83,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'parkingVoirieOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="'parkingsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
@@ -47,9 +47,9 @@ export class ParkSaisieDonneesPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.parkingOnglet.estTermine = this.statusService.getStatus('parkingVoirieOnglet');
+    this.parkingOnglet.estTermine = this.statusService.getStatus('parkingsOnglet');
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.parkingOnglet.estTermine = s['parkingVoirieOnglet'] ?? false;
+      this.parkingOnglet.estTermine = s['parkingsOnglet'] ?? false;
     });
 
     this.route.paramMap.subscribe(params => {
@@ -76,6 +76,8 @@ export class ParkSaisieDonneesPageComponent implements OnInit {
         const model = this.mapper.fromDto(data);
         this.parkingOnglet.parkings = model.parkings;
         this.parkingOnglet.note = model.note;
+        this.parkingOnglet.estTermine = model.estTermine ?? false;
+        this.statusService.setStatus('parkingsOnglet', this.parkingOnglet.estTermine);
       },
       error: err => console.error("Erreur lors du chargement des données", err)
     });


### PR DESCRIPTION
## Summary
- sync estTermine status buttons with dashboard icons via `OngletStatusService`
- load onglet statuses from backend on dashboard
- update each tab page to set status on data load
- align footer path names with dashboard identifiers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b94e307c883329641cadea622a49b