### PR TITLE
Load onglet status when dashboard loads

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -102,6 +102,7 @@ export class DashboardComponent {
   }
   @Input() entiteId!: number;
   ongletIdMap: { [key: string]: number } = {};
+  statuses: Record<string, boolean> = {};
 
   ngOnInit(): void {
     this.currentYear = new Date().getFullYear();
@@ -113,12 +114,16 @@ export class DashboardComponent {
 
     this.selectedYear = this.yearService.getSelectedYear();
 
+    this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
+      this.statuses = s;
+    });
+
     this.loadOngletIds();
     this.loadOngletStatuses();
   }
 
   getStatus(key: string): boolean {
-    return this.statusService.getStatus(key);
+    return this.statuses[key] ?? false;
   }
 
   goToSaisie(onglet: { statusKey: string; route: string }): void {


### PR DESCRIPTION
## Summary
- subscribe to status service in dashboard init
- keep status records locally for easier access

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0fc797c8332a0cd9c5222fd332e