### PR TITLE
Correct dashboard status keys

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -29,12 +29,12 @@ export class DashboardComponent implements OnInit {
     },
     {
       label: 'Emissions fugitives',
-      statusKey: 'emissionFugitiveOnglet',
+      statusKey: 'emissionsFugitivesOnglet',
       route: 'emissionFugitiveOnglet'
     },
     {
       label: 'Mobilité dom-trav',
-      statusKey: 'mobiliteDomicileTravailOnglet',
+      statusKey: 'mobiliteDomTravOnglet',
       route: 'mobiliteDomicileTravailOnglet'
     },
     {
@@ -44,22 +44,22 @@ export class DashboardComponent implements OnInit {
     },
     {
       label: 'Mob internatio',
-      statusKey: 'mobInternationalOnglet',
+      statusKey: 'mobInternationaleOnglet',
       route: 'mobInternationalOnglet'
     },
     {
       label: 'Bâtiments',
-      statusKey: 'batimentImmobilisationMobilierOnglet',
+      statusKey: 'batimentsOnglet',
       route: 'batimentImmobilisationMobilierOnglet'
     },
     {
       label: 'Parkings',
-      statusKey: 'parkingVoirieOnglet',
+      statusKey: 'parkingsOnglet',
       route: 'parkingVoirieOnglet'
     },
     {
       label: 'Auto',
-      statusKey: 'vehiculeOnglet',
+      statusKey: 'autoOnglet',
       route: 'vehiculeOnglet'
     },
     {
@@ -79,7 +79,7 @@ export class DashboardComponent implements OnInit {
     },
     {
       label: 'Déchets',
-      statusKey: 'dechetOnglet',
+      statusKey: 'dechetsOnglet',
       route: 'dechetOnglet'
     }
   ];

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -94,7 +94,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
       (data) => {
         this.items = { ...this.items, ...data };
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('immobOnglet', this.estTermine);
+        this.statusService.setStatus('autreImmobilisationOnglet', this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -64,7 +64,7 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
           this.destinations = data.destinations;
         }
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('mobiliteInternationaleOnglet', this.estTermine);
+        this.statusService.setStatus('mobInternationaleOnglet', this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);


### PR DESCRIPTION
## Summary
- update status keys used in Dashboard so they match the values stored by the pages
- fix `setStatus` key for mobility international tab
- fix `setStatus` key for other immobilisation tab

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc7b21dec8332b905b4d4c0fd5f9d