### PR TITLE
Fix dashboard link

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -154,8 +154,13 @@ export class DashboardComponent implements OnInit {
 
 
 
-  goToEnergie() {
-    this.router.navigate([`/energieOnglet/7`]);
+  goToEnergie(): void {
+    const ongletId = this.ongletIdMap['energieOnglet'];
+    if (ongletId) {
+      this.router.navigate([`/energieOnglet/${ongletId}`]);
+    } else {
+      console.error('ID onglet énergie introuvable pour l\'année', this.selectedYear);
+    }
   }
 
   onYearChange(newYear: number): void {


### PR DESCRIPTION
## Summary
- make dashboard energy link use mapped ID instead of a constant

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bca9ba6fc83329e2633dc57cf6c90