### PR TITLE
Refactor dashboard path mapping

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -7,6 +7,7 @@ import { OngletService } from '../header-saisie-donnees/onglet.service';
 import { AnneeService} from '../../services/annee.service';
 import {AuthService} from '../../services/auth.service';
 import {ApiEndpoints} from '../../services/api-endpoints';
+import { ONGLET_ROUTES } from '../../constants/onglet-routes';
 
 const extractRoute = (url: string): string =>
   url.split('/').slice(3).join('/').replace(/\/$/, '');
@@ -29,62 +30,62 @@ export class DashboardComponent implements OnInit {
     {
       label: 'Energie',
       statusKey: 'energieOnglet',
-      route: extractRoute(ApiEndpoints.EnergieOnglet.getById(''))
+      route: ONGLET_ROUTES['Energie']
     },
     {
       label: 'Emissions fugitives',
       statusKey: 'emissionsFugitivesOnglet',
-      route: extractRoute(ApiEndpoints.EmissionFugitivesOnglet.update(''))
+      route: ONGLET_ROUTES['Emissions fugitives']
     },
     {
       label: 'Mobilité dom-trav',
       statusKey: 'mobiliteDomTravOnglet',
-      route: extractRoute(ApiEndpoints.DomTravOnglet.getById(''))
+      route: ONGLET_ROUTES['Mobilite dom-trav']
     },
     {
       label: 'Autre mob fr',
       statusKey: 'autreMobFrOnglet',
-      route: extractRoute(ApiEndpoints.AutreMobFrOnglet.getById(''))
+      route: ONGLET_ROUTES['Autre mobilite en France']
     },
     {
       label: 'Mob internatio',
       statusKey: 'mobInternationaleOnglet',
-      route: extractRoute(ApiEndpoints.mobInternationaleOnglet.getById(''))
+      route: ONGLET_ROUTES['Mob internationale']
     },
     {
       label: 'Bâtiments',
       statusKey: 'batimentsOnglet',
-      route: extractRoute(ApiEndpoints.BatimentsOnglet.getBatimentImmobilisationMobilier(''))
+      route: ONGLET_ROUTES['Batiments']
     },
     {
       label: 'Parkings',
       statusKey: 'parkingsOnglet',
-      route: extractRoute(ApiEndpoints.ParkingVoirieOnglet.getById(''))
+      route: ONGLET_ROUTES['Parkings']
     },
     {
       label: 'Auto',
       statusKey: 'autoOnglet',
-      route: extractRoute(ApiEndpoints.AutoOnglet.getById(''))
+      route: ONGLET_ROUTES['Auto']
     },
     {
       label: 'Numérique',
       statusKey: 'numeriqueOnglet',
-      route: extractRoute(ApiEndpoints.NumeriqueOnglet.getById(''))
+      route: ONGLET_ROUTES['Numerique']
     },
     {
       label: 'Autres immob',
       statusKey: 'autreImmobilisationOnglet',
-      route: extractRoute(ApiEndpoints.autreImmobilisationOnglet.getById(''))
+      route: ONGLET_ROUTES['Autre immob']
     },
     {
       label: 'Achats',
       statusKey: 'achatOnglet',
-      route: extractRoute(ApiEndpoints.AchatsOnglet.getById(''))
+      route: ONGLET_ROUTES['Achats']
     },
     {
       label: 'Déchets',
       statusKey: 'dechetsOnglet',
-      route: extractRoute(ApiEndpoints.DechetsOnglet.getById(''))
+      route: ONGLET_ROUTES['Dechets']
     }
   ];
 

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -16,6 +16,7 @@ import {FormsModule} from '@angular/forms';
 import {AuthService} from '../../services/auth.service';
 import {AnneeService} from '../../services/annee.service';
 import {Subscription} from 'rxjs';
+import {ONGLET_ROUTES} from '../../constants/onglet-routes';
 
 type YearRange = { label: string; value: number };
 
@@ -166,18 +167,5 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
     this.router.navigate([`/trajectoire`]);
   }
 
-  private tabToRoute: { [key: string]: string } = {
-    'Energie': 'energieOnglet',
-    'Emissions fugitives': 'emissionFugitiveOnglet',
-    'Mobilite dom-trav': 'mobiliteDomicileTravailOnglet',
-    'Autre mobilite en France': 'autreMobFrOnglet',
-    'Mob internationale': 'mobInternationalOnglet',
-    'Batiments': 'batimentImmobilisationMobilierOnglet',
-    'Parkings': 'parkingVoirieOnglet',
-    'Auto': 'vehiculeOnglet',
-    'Numerique': 'numeriqueOnglet',
-    'Autre immob': 'autreImmobilisationOnglet',
-    'Achats': 'achatOnglet',
-    'Dechets': 'dechetOnglet'
-  };
+  private tabToRoute = ONGLET_ROUTES;
 }

--- a/frontend/src/app/constants/onglet-routes.ts
+++ b/frontend/src/app/constants/onglet-routes.ts
@@ -1,0 +1,14 @@
+export const ONGLET_ROUTES: { [key: string]: string } = {
+  'Energie': 'energieOnglet',
+  'Emissions fugitives': 'emissionFugitiveOnglet',
+  'Mobilite dom-trav': 'mobiliteDomicileTravailOnglet',
+  'Autre mobilite en France': 'autreMobFrOnglet',
+  'Mob internationale': 'mobInternationalOnglet',
+  'Batiments': 'batimentImmobilisationMobilierOnglet',
+  'Parkings': 'parkingVoirieOnglet',
+  'Auto': 'vehiculeOnglet',
+  'Numerique': 'numeriqueOnglet',
+  'Autre immob': 'autreImmobilisationOnglet',
+  'Achats': 'achatOnglet',
+  'Dechets': 'dechetOnglet'
+};


### PR DESCRIPTION
## Summary
- centralize tab routes under `ONGLET_ROUTES`
- reuse this map in `HeaderSaisieDonneesComponent`
- update `DashboardComponent` to use the same paths for `goToSaisie`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd45098648332aa2465ee4b87f246