### PR TITLE
Add Synthese EGES page

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -36,6 +36,7 @@ import {
   BatimentsSaisieDonneesPageComponent
 } from './components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component';
 import {TrajectoireComponent} from './components/affichage-graphiques/suivi/trajectoire-page.component';
+import {SyntheseEgesComponent} from './components/affichage-graphiques/synthese/synthese-eges-page.component';
 
 export const routes: Routes = [
   {
@@ -134,6 +135,11 @@ export const routes: Routes = [
   {
     path: 'trajectoire',
     component: TrajectoireComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'synthese-eges',
+    component: SyntheseEgesComponent,
     canActivate: [authGuard]
   },
   {

--- a/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.html
+++ b/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.html
@@ -14,7 +14,7 @@
 
   <nav class="tabs">
     <div class="tabs-container">
-      <button class="tab-button">Récap</button>
+      <button class="tab-button" (click)="goToRecap()">Récap</button>
       <button class="tab-button active">Suivi</button>
     </div>
   </nav>

--- a/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.ts
+++ b/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.ts
@@ -26,6 +26,10 @@ export class TrajectoireComponent implements OnInit {
     navigateToDashboard() {
     this.router.navigate(['/dashboard']);
   }
+
+  goToRecap() {
+    this.router.navigate(['/synthese-eges']);
+  }
   ngOnInit(): void {
     this.loadIndicators();
   }

--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Synthèse EGES</title>
+  <link rel="stylesheet" href="synthese-eges-page.component.scss" />
+</head>
+<body>
+<div class="container">
+  <header>
+    <button class="button home-button" (click)="navigateToDashboard()">Accueil</button>
+  </header>
+
+  <nav class="tabs">
+    <div class="tabs-container">
+      <button class="tab-button active">Récap</button>
+      <button class="tab-button" (click)="goToSuivi()">Suivi</button>
+    </div>
+  </nav>
+
+  <main>
+    <h2 class="table-title">BILAN PAR SECTEUR</h2>
+    <table class="indicator-table">
+      <thead>
+      <tr>
+        <th></th>
+        <th>Au global en Tonnes CO2e</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr *ngFor="let s of sectors">
+        <td>{{ s.label }}</td>
+        <td>{{ s.value }}</td>
+      </tr>
+      <tr class="total">
+        <td>Bilan carbone total</td>
+        <td>{{ total }}</td>
+      </tr>
+      </tbody>
+    </table>
+  </main>
+</div>
+</body>
+</html>

--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.scss
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.scss
@@ -1,0 +1,116 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #fcefe3;
+  color: #333;
+}
+
+.container {
+  max-width: 1200px;
+  margin: auto;
+  padding: 16px;
+}
+
+header {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.home-icon {
+  margin-right: 8px;
+}
+
+.tabs {
+  display: flex;
+  background-color: #fef7f5;
+  border-bottom: 2px solid #d3d3d3;
+  margin-bottom: 16px;
+}
+
+.tab {
+  padding: 12px 24px;
+  cursor: pointer;
+  color: #444;
+  border-bottom: 3px solid transparent;
+}
+
+.tab.active {
+  color: #0077c8;
+  border-bottom: 3px solid #0077c8;
+  font-weight: bold;
+}
+
+main {
+  background-color: white;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.table-title {
+  background-color: #cfe2f3;
+  text-align: center;
+  padding: 10px;
+  margin-top: 0;
+  font-size: 18px;
+  color: #333;
+}
+
+.indicator-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.indicator-table th,
+.indicator-table td {
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+.indicator-table thead {
+  background-color: #efefef;
+}
+
+.indicator-table .section td {
+  background-color: #dbeef3;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.green {
+  color: green;
+  font-weight: bold;
+}
+.tabs-container {
+  display: flex;
+  width: 100%;
+  background-color: #f7f1f1; /* Couleur de fond du rectangle */
+  border-radius: 5px 5px 0 0;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.tab-button {
+  flex: 1;
+  padding: 12px;
+  background-color: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.tab-button:hover {
+  background-color: #f0f0f0;
+}
+
+.tab-button.active {
+  border-bottom: 3px solid #329dd5; /* Couleur bleue soulignée */
+  background-color: #ffffff;
+}

--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+interface Sector {
+  label: string;
+  value: number;
+}
+
+@Component({
+  selector: 'app-synthese-eges',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './synthese-eges-page.component.html',
+  styleUrls: ['./synthese-eges-page.component.scss']
+})
+export class SyntheseEgesComponent implements OnInit {
+  sectors: Sector[] = [];
+  total: number = 0;
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.loadSectors();
+  }
+
+  navigateToDashboard() {
+    this.router.navigate(['/dashboard']);
+  }
+
+  goToSuivi() {
+    this.router.navigate(['/trajectoire']);
+  }
+
+  loadSectors(): void {
+    this.sectors = [
+      { label: 'Emissions fugitives', value: 0 },
+      { label: 'Energie', value: 0 },
+      { label: 'Déplacements domicile - travail', value: 0 },
+      { label: 'Autres déplacements France', value: 0 },
+      { label: 'Déplacements internationaux', value: 0 },
+      { label: 'Bâtiments, mobilier et parkings', value: 0 },
+      { label: 'Numérique', value: 0 },
+      { label: 'Autres immobilisations', value: 0 },
+      { label: 'Achats', value: 0 },
+      { label: 'Déchets', value: 0 }
+    ];
+    this.total = this.sectors.reduce((sum, s) => sum + s.value, 0);
+  }
+}

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.html
@@ -15,7 +15,7 @@
 
     <!-- Boutons Suivi et Récap -->
     <button class="button primary-button" (click)="goToTrajectoire()">Trajectoire</button>
-    <button class="button primary-button">Synthèse EGES en 2024-25</button>
+    <button class="button primary-button" (click)="goToSynthese()">Synthèse EGES en 2024-25</button>
 
     <!-- Changer d'année + Sélecteur -->
     <div class="year-change-container">

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -155,6 +155,10 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
     this.router.navigate([`/trajectoire`]);
   }
 
+  goToSynthese() {
+    this.router.navigate(['/synthese-eges']);
+  }
+
   private tabToRoute: { [key: string]: string } = {
     'Energie': 'energieOnglet',
     'Emissions fugitives': 'emissionFugitiveOnglet',


### PR DESCRIPTION
## Summary
- create new Synthese EGES 2024-25 page
- link Synthese and Trajectoire pages via navigation buttons
- add routing for the new page

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd5b834e8833281200b8af9f23d91