### PR TITLE
Centralize onglet keys

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -36,6 +36,7 @@ import {
   BatimentsSaisieDonneesPageComponent
 } from './components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component';
 import {TrajectoireComponent} from './components/affichage-graphiques/suivi/trajectoire-page.component';
+import { ONGLET_KEYS } from './constants/onglet-keys';
 
 export const routes: Routes = [
   {
@@ -60,73 +61,73 @@ export const routes: Routes = [
   },
 
   {
-    path: 'energieOnglet/:id',
+    path: `${ONGLET_KEYS.Energie}/:id`,
     component: EnergieSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard],
   },
   {
-    path: 'emissionFugitiveOnglet/:id',
+    path: `${ONGLET_KEYS.EmissionsFugitives}/:id`,
     component: EmissFugiSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'dechetOnglet/:id',
+    path: `${ONGLET_KEYS.Dechets}/:id`,
     component: DechetSaisieDonneesPageComponent,
     data: {showSaisieHeader: true},
     canActivate: [authGuard],
   },
   {
-    path: 'mobiliteDomicileTravailOnglet/:id',
+    path: `${ONGLET_KEYS.MobiliteDomTrav}/:id`,
     component: DomTravSaisieDonneesPageComponent,
     data: {showSaisieHeader: true},
     canActivate: [authGuard],
   },
   {
-    path: 'autreMobFrOnglet/:id',
+    path: `${ONGLET_KEYS.AutreMobFr}/:id`,
     component: AutreMobSaisieDonneesPageComponent,
     data: {showSaisieHeader: true},
     canActivate: [authGuard],
   },
   {
-    path: 'achatOnglet/:id',
+    path: `${ONGLET_KEYS.Achats}/:id`,
     component: AchatsSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'autreImmobilisationOnglet/:id',
+    path: `${ONGLET_KEYS.AutreImmob}/:id`,
     component: AutreImmobilisationPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'numeriqueOnglet/:id',
+    path: `${ONGLET_KEYS.Numerique}/:id`,
     component: NumeriqueSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'vehiculeOnglet/:id',
+    path: `${ONGLET_KEYS.Auto}/:id`,
     component: AutoSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'parkingVoirieOnglet/:id',
+    path: `${ONGLET_KEYS.Parkings}/:id`,
     component: ParkSaisieDonneesPageComponent,
     data: { showSaisieHeader: true },
     canActivate: [authGuard]
   },
   {
-    path: 'mobInternationalOnglet/:id',
+    path: `${ONGLET_KEYS.MobInternationale}/:id`,
     data: { showSaisieHeader: true },
     component: MobiliteInternationaleSaisieDonneesPageComponent,
     canActivate: [authGuard]
   },
   {
-    path: 'batimentImmobilisationMobilierOnglet/:id',
+    path: `${ONGLET_KEYS.Batiments}/:id`,
     data: { showSaisieHeader: true },
     component: BatimentsSaisieDonneesPageComponent,
     canActivate: [authGuard]

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -6,8 +6,7 @@ import { OngletStatusService } from '../../services/onglet-status.service';
 import { OngletService } from '../header-saisie-donnees/onglet.service';
 import { AnneeService} from '../../services/annee.service';
 import {AuthService} from '../../services/auth.service';
-import {ApiEndpoints} from '../../services/api-endpoints';
-import { ONGLET_ROUTES } from '../../constants/onglet-routes';
+import { ONGLET_KEYS } from '../../constants/onglet-keys';
 
 const extractRoute = (url: string): string =>
   url.split('/').slice(3).join('/').replace(/\/$/, '');
@@ -27,66 +26,18 @@ export class DashboardComponent implements OnInit {
   years: YearRange[] = [];
 
   onglets = [
-    {
-      label: 'Energie',
-      statusKey: 'energieOnglet',
-      route: ONGLET_ROUTES['Energie']
-    },
-    {
-      label: 'Emissions fugitives',
-      statusKey: 'emissionsFugitivesOnglet',
-      route: ONGLET_ROUTES['Emissions fugitives']
-    },
-    {
-      label: 'Mobilité dom-trav',
-      statusKey: 'mobiliteDomTravOnglet',
-      route: ONGLET_ROUTES['Mobilite dom-trav']
-    },
-    {
-      label: 'Autre mob fr',
-      statusKey: 'autreMobFrOnglet',
-      route: ONGLET_ROUTES['Autre mobilite en France']
-    },
-    {
-      label: 'Mob internatio',
-      statusKey: 'mobInternationaleOnglet',
-      route: ONGLET_ROUTES['Mob internationale']
-    },
-    {
-      label: 'Bâtiments',
-      statusKey: 'batimentsOnglet',
-      route: ONGLET_ROUTES['Batiments']
-    },
-    {
-      label: 'Parkings',
-      statusKey: 'parkingsOnglet',
-      route: ONGLET_ROUTES['Parkings']
-    },
-    {
-      label: 'Auto',
-      statusKey: 'autoOnglet',
-      route: ONGLET_ROUTES['Auto']
-    },
-    {
-      label: 'Numérique',
-      statusKey: 'numeriqueOnglet',
-      route: ONGLET_ROUTES['Numerique']
-    },
-    {
-      label: 'Autres immob',
-      statusKey: 'autreImmobilisationOnglet',
-      route: ONGLET_ROUTES['Autre immob']
-    },
-    {
-      label: 'Achats',
-      statusKey: 'achatOnglet',
-      route: ONGLET_ROUTES['Achats']
-    },
-    {
-      label: 'Déchets',
-      statusKey: 'dechetsOnglet',
-      route: ONGLET_ROUTES['Dechets']
-    }
+    { label: 'Energie', statusKey: ONGLET_KEYS.Energie, route: ONGLET_KEYS.Energie },
+    { label: 'Emissions fugitives', statusKey: ONGLET_KEYS.EmissionsFugitives, route: ONGLET_KEYS.EmissionsFugitives },
+    { label: 'Mobilité dom-trav', statusKey: ONGLET_KEYS.MobiliteDomTrav, route: ONGLET_KEYS.MobiliteDomTrav },
+    { label: 'Autre mob fr', statusKey: ONGLET_KEYS.AutreMobFr, route: ONGLET_KEYS.AutreMobFr },
+    { label: 'Mob internatio', statusKey: ONGLET_KEYS.MobInternationale, route: ONGLET_KEYS.MobInternationale },
+    { label: 'Bâtiments', statusKey: ONGLET_KEYS.Batiments, route: ONGLET_KEYS.Batiments },
+    { label: 'Parkings', statusKey: ONGLET_KEYS.Parkings, route: ONGLET_KEYS.Parkings },
+    { label: 'Auto', statusKey: ONGLET_KEYS.Auto, route: ONGLET_KEYS.Auto },
+    { label: 'Numérique', statusKey: ONGLET_KEYS.Numerique, route: ONGLET_KEYS.Numerique },
+    { label: 'Autres immob', statusKey: ONGLET_KEYS.AutreImmob, route: ONGLET_KEYS.AutreImmob },
+    { label: 'Achats', statusKey: ONGLET_KEYS.Achats, route: ONGLET_KEYS.Achats },
+    { label: 'Déchets', statusKey: ONGLET_KEYS.Dechets, route: ONGLET_KEYS.Dechets }
   ];
 
   constructor(
@@ -144,9 +95,9 @@ export class DashboardComponent implements OnInit {
     this.ongletService.getOngletIds(this.entiteId, this.selectedYear)?.subscribe({
       next: (result) => {
         this.ongletIdMap = result;
-        const ongletId = this.ongletIdMap['energieOnglet'];
+        const ongletId = this.ongletIdMap[ONGLET_KEYS.Energie];
         if (ongletId) {
-          this.router.navigate([`/energieOnglet/${ongletId}`]);
+          this.router.navigate([`/${ONGLET_KEYS.Energie}/${ongletId}`]);
         } else {
           console.error('ID onglet énergie introuvable pour l’année', this.selectedYear);
         }
@@ -160,9 +111,9 @@ export class DashboardComponent implements OnInit {
 
 
   goToEnergie(): void {
-    const ongletId = this.ongletIdMap['energieOnglet'];
+    const ongletId = this.ongletIdMap[ONGLET_KEYS.Energie];
     if (ongletId) {
-      this.router.navigate([`/energieOnglet/${ongletId}`]);
+      this.router.navigate([`/${ONGLET_KEYS.Energie}/${ongletId}`]);
     } else {
       console.error('ID onglet énergie introuvable pour l\'année', this.selectedYear);
     }

--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -45,8 +45,7 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
 
   ongletIdMap: { [key: string]: number } = {};
 
-  tabs = ['Energie', 'Emissions fugitives', 'Mobilite dom-trav', 'Autre mobilite en France', 'Mob internationale', 'Batiments',
-    'Parkings', 'Auto', 'Numerique', 'Autre immob', 'Achats', 'Dechets'];
+  tabs = Object.keys(ONGLET_ROUTES);
   startIndex = 0;
   visibleCount = 12;
   loading = false;

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -92,5 +92,5 @@
       </div>
     </div>
   </div>
-  <app-save-footer [path]="'achatOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Achats" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.ts
@@ -8,6 +8,7 @@ import { CommonModule } from '@angular/common';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
 import { AchatMapperService } from './achat-mapper.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-achats-saisie-donnees-page',
@@ -25,6 +26,7 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
 
   items: any = {};
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   consommablesFields = [
     { label: 'Papier', unit: 'Tonnes', key: 'papierCons' },
@@ -96,9 +98,9 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('achatOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.Achats);
     this.statusService.statuses$.subscribe((statuses: Record<string, boolean>) => {
-      this.estTermine = statuses['achatOnglet'] ?? false;
+      this.estTermine = statuses[ONGLET_KEYS.Achats] ?? false;
     });
 
     this.route.paramMap.subscribe(params => {
@@ -119,7 +121,7 @@ export class AchatsSaisieDonneesPageComponent implements OnInit {
       next: data => {
         this.items = this.mapper.fromDto(data);
         this.estTermine = this.items.estTermine ?? false;
-        this.statusService.setStatus('achatOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Achats, this.estTermine);
       },
       error: err => console.error("Erreur de chargement", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -58,5 +58,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'autoOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Auto" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.ts
@@ -7,6 +7,7 @@ import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { VehiculeOngletMapperService } from './vehicule-onglet-mapper.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import { VEHICULE_TYPE } from '../../../models/enums/vehicule.enum';
 import { Vehicule, VehiculeOngletModel } from '../../../models/vehicule.model';
 import { OngletStatusService } from '../../../services/onglet-status.service';
@@ -40,15 +41,17 @@ export class AutoSaisieDonneesPageComponent implements OnInit {
     { value: VEHICULE_TYPE.ELECTRIQUE, label: 'Électrique' }
   ];
 
+  ONGLET_KEYS = ONGLET_KEYS;
+
   getLibelleTypeVehicule(type: string): string {
     const item = this.vehiculeTypesLibelles.find(t => t.value === type);
     return item ? item.label : type;
   }
 
   ngOnInit(): void {
-    this.vehiculeOnglet.estTermine = this.statusService.getStatus('autoOnglet');
+    this.vehiculeOnglet.estTermine = this.statusService.getStatus(ONGLET_KEYS.Auto);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.vehiculeOnglet.estTermine = s['autoOnglet'] ?? false;
+      this.vehiculeOnglet.estTermine = s[ONGLET_KEYS.Auto] ?? false;
     });
 
     const id = this.route.snapshot.paramMap.get('id');
@@ -73,7 +76,7 @@ export class AutoSaisieDonneesPageComponent implements OnInit {
         this.vehiculeOnglet.vehicules = model.vehicules;
         this.vehiculeOnglet.note = model.note;
         this.vehiculeOnglet.estTermine = model.estTermine ?? false;
-        this.statusService.setStatus('autoOnglet', this.vehiculeOnglet.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Auto, this.vehiculeOnglet.estTermine);
       },
       error: err => console.error('Erreur lors du chargement des véhicules', err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -134,6 +134,6 @@
         </table>
       </div>
     </div>
-    <app-save-footer [path]="'autreImmobilisationOnglet'"></app-save-footer>
+    <app-save-footer [path]="ONGLET_KEYS.AutreImmob"></app-save-footer>
   </div>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -7,6 +7,7 @@ import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -58,6 +59,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
   };
 
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   onEstTermineChange(value: boolean): void {
     this.estTermine = value;
@@ -65,9 +67,9 @@ export class AutreImmobilisationPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('autreImmobilisationOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.AutreImmob);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['autreImmobilisationOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.AutreImmob] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
@@ -94,7 +96,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
       (data) => {
         this.items = { ...this.items, ...data };
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('autreImmobilisationOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.AutreImmob, this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.html
@@ -50,5 +50,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'autreMobFrOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.AutreMobFr" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-mob/autre-mob-saisie-donnees-page.component.ts
@@ -13,6 +13,7 @@ import { AuthService } from '../../../services/auth.service';
 import { TransportAutreMobMapperService} from './transport-data-autre-mob-mapper.service';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-autre-mob-saisie-donnees-page',
@@ -31,14 +32,15 @@ export class AutreMobSaisieDonneesPageComponent implements OnInit {
   items: TransportAutreMob[] = [];
 
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   transportModes = Object.values(MODE_TRANSPORT_AUTRE_MOB);
   travelerGroups = Object.values(GROUPE_VOYAGEURS);
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('autreMobFrOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.AutreMobFr);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['autreMobFrOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.AutreMobFr] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) this.loadData(id);
@@ -57,7 +59,7 @@ export class AutreMobSaisieDonneesPageComponent implements OnInit {
       next: data => {
         this.items = this.mapper.parseFlatData(data);
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('autreMobFrOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.AutreMobFr, this.estTermine);
       },
       error: err => console.error('Erreur chargement autre mob:', err),
     });

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -253,5 +253,5 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     </table>
   </div>
   <hr/>
-  <app-save-footer [path]="'batimentsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Batiments" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.ts
@@ -9,6 +9,8 @@ import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { BatimentOngletMapperService } from './batiment-onglet-mapper.service';
 import { BatimentOngletModel, BatimentExistantOuNeufConstruit, EntretienCourant, MobilierElectromenager } from '../../../models/batiment.model';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import {
   EnumBatiment_TypeBatiment,
   EnumBatiment_TypeStructure,
@@ -30,6 +32,7 @@ export class BatimentsSaisieDonneesPageComponent implements OnInit {
   private mapper = inject(BatimentOngletMapperService);
   private statusService = inject(OngletStatusService);
   batimentOngletId: string = '';
+  ONGLET_KEYS = ONGLET_KEYS;
   batimentTypes = Object.values(EnumBatiment_TypeBatiment);
   structureTypes = Object.values(EnumBatiment_TypeStructure);
   travauxTypes = Object.values(EnumBatiment_TypeTravaux);
@@ -178,9 +181,9 @@ export class BatimentsSaisieDonneesPageComponent implements OnInit {
 
 
   ngOnInit(): void {
-    this.batimentOnglet.estTermine = this.statusService.getStatus('batimentsOnglet');
+    this.batimentOnglet.estTermine = this.statusService.getStatus(ONGLET_KEYS.Batiments);
     this.statusService.statuses$.subscribe(s => {
-      this.batimentOnglet.estTermine = s['batimentsOnglet'] ?? false;
+      this.batimentOnglet.estTermine = s[ONGLET_KEYS.Batiments] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       this.batimentOngletId = params.get('id') || '';
@@ -198,7 +201,7 @@ export class BatimentsSaisieDonneesPageComponent implements OnInit {
         const model = this.mapper.fromDto(data);
         this.batimentOnglet = model;
         this.batimentOnglet.estTermine = model.estTermine ?? false;
-        this.statusService.setStatus('batimentsOnglet', this.batimentOnglet.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Batiments, this.batimentOnglet.estTermine);
       },
       error: (error) => {
         console.error('Erreur lors de la récupération des données :', error);

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.html
@@ -45,5 +45,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'dechetsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Dechets" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dechets/dechets-saisie-donnees-page.component.ts
@@ -11,6 +11,7 @@ import { ApiEndpoints } from '../../../services/api-endpoints';
 import { AuthService } from '../../../services/auth.service';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-dechet-saisie-donnees-page',
@@ -29,14 +30,15 @@ export class DechetSaisieDonneesPageComponent implements OnInit {
   items: DechetData[] = [];
 
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   types = Object.values(TYPE_DECHET);
   traitements = Object.values(TRAITEMENT_DECHET);
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('dechetsOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.Dechets);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['dechetsOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.Dechets] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) this.loadData(id);
@@ -54,7 +56,7 @@ export class DechetSaisieDonneesPageComponent implements OnInit {
       next: data => {
         this.items = this.mapper.parseData(data);
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('dechetsOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Dechets, this.estTermine);
       },
       error: err => console.error('Erreur chargement déchets:', err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -54,5 +54,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'mobiliteDomTravOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.MobiliteDomTrav" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.ts
@@ -10,6 +10,7 @@ import {TransportDomTrav} from '../../../models/transport-data.model';
 import {TransportDataDomTravMapperService} from './transport-data-dom-trav-mapper.service';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-dom-trav-saisie-donnees-page',
@@ -35,12 +36,13 @@ export class DomTravSaisieDonneesPageComponent implements OnInit {
   nbJoursSalarie?: number;
 
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('mobiliteDomTravOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.MobiliteDomTrav);
     this.statusService.statuses$.subscribe(s => {
-      this.estTermine = s['mobiliteDomTravOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.MobiliteDomTrav] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) this.loadData(id);
@@ -64,7 +66,7 @@ export class DomTravSaisieDonneesPageComponent implements OnInit {
         this.nbJoursEtudiant = data.nbJoursDeplacementEtudiant ?? 0;
         this.nbJoursSalarie = data.nbJoursDeplacementSalarie ?? 0;
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('mobiliteDomTravOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.MobiliteDomTrav, this.estTermine);
       },
       error: (err) => console.error("Erreur lors du chargement des données", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.html
@@ -121,5 +121,5 @@
       </div>
     </div>
   </div>
-  <app-save-footer [path]="'emissionsFugitivesOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.EmissionsFugitives" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/emiss-fugi/emiss-fugi-saisie-donnees-page.component.ts
@@ -10,6 +10,7 @@ import {TypeFluideLabels} from '../../../models/typeFluide-label';
 import {TypeMachineLabels} from '../../../models/type-machine-labels'
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -30,6 +31,8 @@ export class EmissFugiSaisieDonneesPageComponent implements OnInit {
   noData: boolean = false;
   hasError: boolean = false;
   fluideTypes = Object.values(TypeFluide);
+
+  ONGLET_KEYS = ONGLET_KEYS;
 
   fluideTypesLibelles = [
     { value: TypeFluide.CH4, label: "CH4" },
@@ -128,9 +131,9 @@ export class EmissFugiSaisieDonneesPageComponent implements OnInit {
   constructor(private emmissionsFugtivesService: EmmissionsFugtivesService) {}
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('emissionsFugitivesOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.EmissionsFugitives);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['emissionsFugitivesOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.EmissionsFugitives] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       this.emmissionFugitiveOngletId = params.get('id') || '';
@@ -186,7 +189,7 @@ export class EmissFugiSaisieDonneesPageComponent implements OnInit {
         this.noData = this.machines.length === 0;
         this.hasError = false;
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('emissionsFugitivesOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.EmissionsFugitives, this.estTermine);
       },
       error: (err) => {
         console.error('Erreur API', err);

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.html
@@ -74,5 +74,5 @@
       </tbody>
     </table>
   </div>
-  <app-save-footer [path]="'energieOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Energie" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/energie/energie-saisie-donnees-page.component.ts
@@ -5,6 +5,7 @@ import {ActivatedRoute} from '@angular/router'; // Permet de récupérer l'ID de
 import {AuthService} from '../../../services/auth.service';
 import {ApiEndpoints} from '../../../services/api-endpoints';
 import {OngletStatusService} from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 
 @Component({
@@ -22,6 +23,7 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
 
   items: any = {}; // Objet qui contiendra les données récupérées
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   onEstTermineChange(value: boolean): void {
     this.estTermine = value;
@@ -29,9 +31,9 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.estTermine = this.statusService.getStatus('energieOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.Energie);
     this.statusService.statuses$.subscribe((statuses: Record<string, boolean>) => {
-      this.estTermine = statuses['energieOnglet'] ?? false;
+      this.estTermine = statuses[ONGLET_KEYS.Energie] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
@@ -69,7 +71,7 @@ export class EnergieSaisieDonneesPageComponent implements OnInit {
           consoEau: data.consoEau
         };
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('energieOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Energie, this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -89,5 +89,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'mobInternationaleOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.MobInternationale" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -8,6 +8,7 @@ import { ApiEndpoints } from '../../../services/api-endpoints';
 import { Pays } from '../../../models/enums/pays.enum';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 
 @Component({
   selector: 'app-destination-page',
@@ -31,13 +32,14 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
   destinations: any[] = [];
 
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   listePays = Object.values(Pays);
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('mobInternationaleOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.MobInternationale);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.estTermine = s['mobInternationaleOnglet'] ?? false;
+      this.estTermine = s[ONGLET_KEYS.MobInternationale] ?? false;
     });
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
@@ -64,7 +66,7 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
           this.destinations = data.destinations;
         }
         this.estTermine = data.estTermine ?? false;
-        this.statusService.setStatus('mobInternationaleOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.MobInternationale, this.estTermine);
       },
       (error) => {
         console.error("Erreur lors du chargement des données", error);

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -84,5 +84,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'numeriqueOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Numerique" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -6,6 +6,7 @@ import {AuthService} from '../../../services/auth.service';
 import {CommonModule} from '@angular/common';
 import {SaveFooterComponent} from '../../save-footer/save-footer.component';
 import {OngletStatusService} from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import {NumeriqueOngletMapperService} from './numerique-onglet-mapper.service';
 import {NumeriqueService} from './numerique.service';
 import {EquipementNumerique, NumeriqueModel} from '../../../models/numerique.model';
@@ -49,6 +50,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
 
   equipementsAnciens: EquipementNumerique[] = [];
   estTermine = false;
+  ONGLET_KEYS = ONGLET_KEYS;
 
   onEstTermineChange(value: boolean): void {
     this.estTermine = value;
@@ -56,9 +58,9 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.estTermine = this.statusService.getStatus('numeriqueOnglet');
+    this.estTermine = this.statusService.getStatus(ONGLET_KEYS.Numerique);
     this.statusService.statuses$.subscribe((statuses: Record<string, boolean>) => {
-      this.estTermine = statuses['numeriqueOnglet'] ?? false;
+      this.estTermine = statuses[ONGLET_KEYS.Numerique] ?? false;
     });
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
@@ -87,7 +89,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
         this.partTraficFranceEtranger = model.partTraficFranceEtranger;
         this.equipementsAnciens = model.equipements;
         this.estTermine = model.estTermine ?? false;
-        this.statusService.setStatus('numeriqueOnglet', this.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Numerique, this.estTermine);
       },
       error: err => console.error("Erreur lors du chargement des données numériques", err)
     });

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -83,5 +83,5 @@
       </table>
     </div>
   </div>
-  <app-save-footer [path]="'parkingsOnglet'" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
+  <app-save-footer [path]="ONGLET_KEYS.Parkings" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.ts
@@ -7,6 +7,7 @@ import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { SaveFooterComponent } from '../../save-footer/save-footer.component';
 import { OngletStatusService } from '../../../services/onglet-status.service';
+import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import { PARKING_VOIRIE_TYPE, PARKING_VOIRIE_TYPE_STRUCTURE } from '../../../models/enums/parking-voirie.enum';
 import { ParkingVoirie, ParkingVoirieOngletModel } from '../../../models/parking-voirie.model';
 import { ParkingVoirieOngletMapperService } from './parking-voirie-onglet-mapper.service';
@@ -40,6 +41,8 @@ export class ParkSaisieDonneesPageComponent implements OnInit {
   parkingTypes = Object.values(PARKING_VOIRIE_TYPE);
   structureTypes = Object.values(PARKING_VOIRIE_TYPE_STRUCTURE);
 
+  ONGLET_KEYS = ONGLET_KEYS;
+
   onEmissionsConnuesChange(value: boolean): void {
     if (!value) {
       this.nouveauParking.emissionsGesReelles = null;
@@ -47,9 +50,9 @@ export class ParkSaisieDonneesPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.parkingOnglet.estTermine = this.statusService.getStatus('parkingsOnglet');
+    this.parkingOnglet.estTermine = this.statusService.getStatus(ONGLET_KEYS.Parkings);
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
-      this.parkingOnglet.estTermine = s['parkingsOnglet'] ?? false;
+      this.parkingOnglet.estTermine = s[ONGLET_KEYS.Parkings] ?? false;
     });
 
     this.route.paramMap.subscribe(params => {
@@ -77,7 +80,7 @@ export class ParkSaisieDonneesPageComponent implements OnInit {
         this.parkingOnglet.parkings = model.parkings;
         this.parkingOnglet.note = model.note;
         this.parkingOnglet.estTermine = model.estTermine ?? false;
-        this.statusService.setStatus('parkingsOnglet', this.parkingOnglet.estTermine);
+        this.statusService.setStatus(ONGLET_KEYS.Parkings, this.parkingOnglet.estTermine);
       },
       error: err => console.error("Erreur lors du chargement des données", err)
     });

--- a/frontend/src/app/constants/onglet-keys.ts
+++ b/frontend/src/app/constants/onglet-keys.ts
@@ -1,0 +1,14 @@
+export enum ONGLET_KEYS {
+  Energie = 'energieOnglet',
+  EmissionsFugitives = 'emissionFugitiveOnglet',
+  MobiliteDomTrav = 'mobiliteDomicileTravailOnglet',
+  AutreMobFr = 'autreMobFrOnglet',
+  MobInternationale = 'mobInternationalOnglet',
+  Batiments = 'batimentImmobilisationMobilierOnglet',
+  Parkings = 'parkingVoirieOnglet',
+  Auto = 'vehiculeOnglet',
+  Numerique = 'numeriqueOnglet',
+  AutreImmob = 'autreImmobilisationOnglet',
+  Achats = 'achatOnglet',
+  Dechets = 'dechetOnglet'
+}

--- a/frontend/src/app/constants/onglet-routes.ts
+++ b/frontend/src/app/constants/onglet-routes.ts
@@ -1,14 +1,16 @@
+import { ONGLET_KEYS } from './onglet-keys';
+
 export const ONGLET_ROUTES: { [key: string]: string } = {
-  'Energie': 'energieOnglet',
-  'Emissions fugitives': 'emissionFugitiveOnglet',
-  'Mobilite dom-trav': 'mobiliteDomicileTravailOnglet',
-  'Autre mobilite en France': 'autreMobFrOnglet',
-  'Mob internationale': 'mobInternationalOnglet',
-  'Batiments': 'batimentImmobilisationMobilierOnglet',
-  'Parkings': 'parkingVoirieOnglet',
-  'Auto': 'vehiculeOnglet',
-  'Numerique': 'numeriqueOnglet',
-  'Autre immob': 'autreImmobilisationOnglet',
-  'Achats': 'achatOnglet',
-  'Dechets': 'dechetOnglet'
+  'Energie': ONGLET_KEYS.Energie,
+  'Emissions fugitives': ONGLET_KEYS.EmissionsFugitives,
+  'Mobilite dom-trav': ONGLET_KEYS.MobiliteDomTrav,
+  'Autre mobilite en France': ONGLET_KEYS.AutreMobFr,
+  'Mob internationale': ONGLET_KEYS.MobInternationale,
+  'Batiments': ONGLET_KEYS.Batiments,
+  'Parkings': ONGLET_KEYS.Parkings,
+  'Auto': ONGLET_KEYS.Auto,
+  'Numerique': ONGLET_KEYS.Numerique,
+  'Autre immob': ONGLET_KEYS.AutreImmob,
+  'Achats': ONGLET_KEYS.Achats,
+  'Dechets': ONGLET_KEYS.Dechets
 };

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -1,3 +1,5 @@
+import { ONGLET_KEYS } from '../constants/onglet-keys';
+
 const BASE_URL = 'http://localhost:8080';
 
 export const ApiEndpoints = {
@@ -7,81 +9,81 @@ export const ApiEndpoints = {
   },
 
   EnergieOnglet: {
-    getById: (id: string) => `${BASE_URL}/energieOnglet/${id}`,
-    updateConso: (id: string) => `${BASE_URL}/energieOnglet/${id}`,
+    getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Energie}/${id}`,
+    updateConso: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Energie}/${id}`,
   },
 
   EmissionFugitivesOnglet: {
-    getMachineById: (id: string) => `${BASE_URL}/emissionFugitiveOnglet/${id}`,
-    addMachine: (id: string) => `${BASE_URL}/emissionFugitiveOnglet/${id}/machine`,
+    getMachineById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.EmissionsFugitives}/${id}`,
+    addMachine: (id: string) => `${BASE_URL}/${ONGLET_KEYS.EmissionsFugitives}/${id}/machine`,
     deleteMachine: (id: string, idMachine: string) =>
-      `${BASE_URL}/emissionFugitiveOnglet/${id}/machine/${idMachine}`,
-    update: (id: string) => `${BASE_URL}/emissionFugitiveOnglet/${id}`,
+      `${BASE_URL}/${ONGLET_KEYS.EmissionsFugitives}/${id}/machine/${idMachine}`,
+    update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.EmissionsFugitives}/${id}`,
   },
 
   DomTravOnglet: {
-    getById: (id: string) => `${BASE_URL}/mobiliteDomicileTravailOnglet/${id}`,
-    update: (id: string) => `${BASE_URL}/mobiliteDomicileTravailOnglet/${id}`,
+    getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.MobiliteDomTrav}/${id}`,
+    update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.MobiliteDomTrav}/${id}`,
   },
 
   AutreMobFrOnglet: {
-    getById: (id: string) => `${BASE_URL}/autreMobFrOnglet/${id}`,
-    update: (id: string) => `${BASE_URL}/autreMobFrOnglet/${id}`,
+    getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.AutreMobFr}/${id}`,
+    update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.AutreMobFr}/${id}`,
   },
 
   DechetsOnglet: {
-    getById: (id: string) => `${BASE_URL}/dechetOnglet/${id}`,
-    update: (id: string) => `${BASE_URL}/dechetOnglet/${id}`,
+    getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Dechets}/${id}`,
+    update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Dechets}/${id}`,
   },
 
   AchatsOnglet: {
-    getById: (id: string) => `${BASE_URL}/achatOnglet/${id}`,
-    update: (id: string) => `${BASE_URL}/achatOnglet/${id}`,
+    getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Achats}/${id}`,
+    update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Achats}/${id}`,
   },
 
 autreImmobilisationOnglet: {
-  getById: (id: string) => `${BASE_URL}/autreImmobilisationOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/autreImmobilisationOnglet/${id}`
+  getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.AutreImmob}/${id}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.AutreImmob}/${id}`
 },
 NumeriqueOnglet: {
-  getById: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}`,
-  addEquipement: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}/equipementNumerique`,
+  getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Numerique}/${id}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Numerique}/${id}`,
+  addEquipement: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Numerique}/${id}/equipementNumerique`,
   deleteEquipement: (ongletId: string, equipId: string) =>
-    `${BASE_URL}/numeriqueOnglet/${ongletId}/equipementNumerique/${equipId}`,
+    `${BASE_URL}/${ONGLET_KEYS.Numerique}/${ongletId}/equipementNumerique/${equipId}`,
   updateEquipement: (ongletId: string, equipId: string) =>
-    `${BASE_URL}/numeriqueOnglet/${ongletId}/equipementNumerique/${equipId}`,
-  getResult: (id: string) => `${BASE_URL}/numeriqueOnglet/${id}/resultat`
+    `${BASE_URL}/${ONGLET_KEYS.Numerique}/${ongletId}/equipementNumerique/${equipId}`,
+  getResult: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Numerique}/${id}/resultat`
 },
 ParkingVoirieOnglet: {
-  getById: (id: string) => `${BASE_URL}/parkingVoirieOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/parkingVoirieOnglet/${id}`,
-  addParking: (id: string) => `${BASE_URL}/parkingVoirieOnglet/${id}/parkingVoirie`,
+  getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}`,
+  addParking: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}/parkingVoirie`,
   deleteParking: (ongletId: string, parkingId: string) =>
-    `${BASE_URL}/parkingVoirieOnglet/${ongletId}/parkingVoirie/${parkingId}`,
+    `${BASE_URL}/${ONGLET_KEYS.Parkings}/${ongletId}/parkingVoirie/${parkingId}`,
   updateParking: (ongletId: string, parkingId: string) =>
-    `${BASE_URL}/parkingVoirieOnglet/${ongletId}/parkingVoirie/${parkingId}`,
-  getResult: (id: string) => `${BASE_URL}/parkingVoirieOnglet/${id}/resultat`
+    `${BASE_URL}/${ONGLET_KEYS.Parkings}/${ongletId}/parkingVoirie/${parkingId}`,
+  getResult: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}/resultat`
 },
 mobInternationaleOnglet: {
-  getById: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`
+  getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.MobInternationale}/${id}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.MobInternationale}/${id}`
 },
 BatimentsOnglet: {
   getBatimentImmobilisationMobilier: (id: string) =>
-    `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}`,
-  ajouterBatiment: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}/batimentExistantOuNeufConstruit`,
-  supprimerBatiment: (tabId: string, batimentId: number) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${tabId}/batimentExistantOuNeufConstruit/${batimentId}`,
+    `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}`,
+  ajouterBatiment: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}/batimentExistantOuNeufConstruit`,
+  supprimerBatiment: (tabId: string, batimentId: number) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${tabId}/batimentExistantOuNeufConstruit/${batimentId}`,
 
-  ajouterEntretien: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}/entretienCourant`,
-  supprimerEntretien: (tabId: string, entretienId: number) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${tabId}/entretienCourant/${entretienId}`,
+  ajouterEntretien: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}/entretienCourant`,
+  supprimerEntretien: (tabId: string, entretienId: number) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${tabId}/entretienCourant/${entretienId}`,
 
-  ajouterMobilier: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}/mobilierElectromenager`,
-  supprimerMobilier: (tabId: string, mobilierId: number) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${tabId}/mobilierElectromenager/${mobilierId}`,
-  update: (id: string) => `${BASE_URL}/batimentImmobilisationMobilierOnglet/${id}`
+  ajouterMobilier: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}/mobilierElectromenager`,
+  supprimerMobilier: (tabId: string, mobilierId: number) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${tabId}/mobilierElectromenager/${mobilierId}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}`
 },
 AutoOnglet: {
-  getById: (id: string) => `${BASE_URL}/vehiculeOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/vehiculeOnglet/${id}`
+  getById: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Auto}/${id}`,
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Auto}/${id}`
 }
 };


### PR DESCRIPTION
## Summary
- add `ONGLET_KEYS` enum for Angular routes
- map readable labels to keys in `ONGLET_ROUTES`
- update dashboard and header to use enum constants
- unify component tabs and API endpoints with new keys
- update router paths to reference `ONGLET_KEYS`

## Testing
- `npm test` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bd935be40833285518c85d4092570