### PR TITLE
Implement dashboard status loading

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,3 +1,7 @@
 <button (click)="goToSaisieDonnees()">Saisir les données</button>
 
+<div *ngIf="statuses">
+  <pre>{{ statuses | json }}</pre>
+</div>
+
 

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
+import { DashboardStatusService } from '../../services/dashboard-status.service';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -8,7 +10,10 @@ describe('DashboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DashboardComponent]
+      imports: [DashboardComponent],
+      providers: [
+        { provide: DashboardStatusService, useValue: { getAllStatuses: () => of({}) } }
+      ]
     })
     .compileComponents();
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,20 +1,29 @@
 import {Component, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Router} from '@angular/router';
+import {DashboardStatusService} from '../../services/dashboard-status.service';
+import {JsonPipe} from '@angular/common';
 
 @Component({
   selector: 'app-dashboard',
   imports: [
-    FormsModule
+    FormsModule,
+    JsonPipe
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss'
 })
 export class DashboardComponent implements OnInit{
-  constructor(private router: Router) {}
+  statuses: any = null;
+
+  constructor(private router: Router, private statusService: DashboardStatusService) {}
 
   ngOnInit() {
-    console.log("Connecté")
+    console.log("Connecté");
+    const id = '2';
+    this.statusService.getAllStatuses(id).subscribe(data => {
+      this.statuses = data;
+    });
   }
 
   goToSaisieDonnees() {

--- a/frontend/src/app/services/dashboard-status.service.ts
+++ b/frontend/src/app/services/dashboard-status.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { forkJoin, Observable, of } from 'rxjs';
+import { AuthService } from './auth.service';
+import { ApiEndpoints } from './api-endpoints';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DashboardStatusService {
+  private http = inject(HttpClient);
+  private authService = inject(AuthService);
+
+  getAllStatuses(id: string): Observable<any> {
+    const token = this.authService.getToken();
+    if (!token) {
+      return of(null);
+    }
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    };
+
+    return forkJoin({
+      energie: this.http.get(ApiEndpoints.EnergieOnglet.getById(id), { headers }),
+      emissionFugitives: this.http.get(ApiEndpoints.EmissionFugitivesOnglet.getMachineById(id), { headers }),
+      domTrav: this.http.get(ApiEndpoints.DomTravOnglet.getById(id), { headers }),
+      autreMob: this.http.get(ApiEndpoints.AutreMobFrOnglet.getById(id), { headers }),
+      dechets: this.http.get(ApiEndpoints.DechetsOnglet.getById(id), { headers }),
+      achats: this.http.get(ApiEndpoints.AchatsOnglet.getById(id), { headers }),
+      immob: this.http.get(ApiEndpoints.ImmobOnglet.getById(id), { headers }),
+      numerique: this.http.get(ApiEndpoints.NumeriqueOnglet.getById(id), { headers }),
+      park: this.http.get(ApiEndpoints.ParkOnglet.getById(id), { headers }),
+      mobInter: this.http.get(ApiEndpoints.MobiliteInternationaleOnglet.getById(id), { headers }),
+      batiments: this.http.get(ApiEndpoints.BatimentsOnglet.getById(id), { headers }),
+      auto: this.http.get(ApiEndpoints.AutoOnglet.getById(id), { headers })
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `DashboardStatusService` to gather all tab status data via API
- load all statuses on dashboard init and show them for debugging
- update dashboard unit test to provide the new service

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc85cc4048332b7a72142700e3875