### PR TITLE
Load dashboard statuses on init

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -75,6 +75,7 @@ export class DashboardComponent implements OnInit {
     });
 
     this.loadOngletIds();
+    // Récupère l'état de chaque onglet dès l'initialisation du dashboard
     this.loadOngletStatuses();
   }
 
@@ -137,6 +138,7 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  // Effectue l'appel HTTP pour récupérer les statuts de tous les onglets
   loadOngletStatuses(): void {
     this.ongletService.getOngletStatuses(this.entiteId, this.selectedYear)?.subscribe({
       next: (result) => {


### PR DESCRIPTION
## Summary
- clarify dashboard init logic to load tab statuses

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc99562688332a6a5af18c290892a