### PR TITLE
Implement dashboard status prefetch

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -7,6 +7,7 @@ import { OngletService } from '../header-saisie-donnees/onglet.service';
 import { AnneeService} from '../../services/annee.service';
 import {AuthService} from '../../services/auth.service';
 import { ONGLET_KEYS } from '../../constants/onglet-keys';
+import { forkJoin } from 'rxjs';
 
 const extractRoute = (url: string): string =>
   url.split('/').slice(3).join('/').replace(/\/$/, '');
@@ -74,8 +75,7 @@ export class DashboardComponent implements OnInit {
       this.statuses = s;
     });
 
-    this.loadOngletIds();
-    this.loadOngletStatuses();
+    this.loadOngletIdsAndStatuses();
   }
 
   getStatus(key: string): boolean {
@@ -122,8 +122,7 @@ export class DashboardComponent implements OnInit {
   onYearChange(newYear: number): void {
     this.selectedYear = newYear;
     this.yearService.setSelectedYear(newYear);
-    this.loadOngletIds();
-    this.loadOngletStatuses();
+    this.loadOngletIdsAndStatuses();
   }
 
   loadOngletIds(): void {
@@ -144,6 +143,22 @@ export class DashboardComponent implements OnInit {
       },
       error: (err) => {
         console.error('Erreur récupération statut onglets:', err);
+      }
+    });
+  }
+
+  loadOngletIdsAndStatuses(): void {
+    const ids$ = this.ongletService.getOngletIds(this.entiteId, this.selectedYear);
+    const status$ = this.ongletService.getOngletStatuses(this.entiteId, this.selectedYear);
+    if (!ids$ || !status$) return;
+
+    forkJoin([ids$, status$]).subscribe({
+      next: ([ids, statuses]) => {
+        this.ongletIdMap = ids;
+        this.statusService.setStatuses(statuses);
+      },
+      error: (err) => {
+        console.error('Erreur récupération onglets:', err);
       }
     });
   }


### PR DESCRIPTION
## Summary
- fetch all tab statuses with IDs in parallel using `forkJoin`
- use new method when dashboard initializes or when year changes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccca544548332a26870321d117d58