### PR TITLE
Fix dashboard status endpoint

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -7,6 +7,7 @@ import { OngletService } from '../header-saisie-donnees/onglet.service';
 import { AnneeService} from '../../services/annee.service';
 import {AuthService} from '../../services/auth.service';
 import { ONGLET_KEYS } from '../../constants/onglet-keys';
+import { forkJoin } from 'rxjs';
 
 const extractRoute = (url: string): string =>
   url.split('/').slice(3).join('/').replace(/\/$/, '');
@@ -74,8 +75,7 @@ export class DashboardComponent implements OnInit {
       this.statuses = s;
     });
 
-    this.loadOngletIds();
-    this.loadOngletStatuses();
+    this.loadOngletIdsAndStatuses();
   }
 
   getStatus(key: string): boolean {
@@ -122,8 +122,7 @@ export class DashboardComponent implements OnInit {
   onYearChange(newYear: number): void {
     this.selectedYear = newYear;
     this.yearService.setSelectedYear(newYear);
-    this.loadOngletIds();
-    this.loadOngletStatuses();
+    this.loadOngletIdsAndStatuses();
   }
 
   loadOngletIds(): void {
@@ -144,6 +143,26 @@ export class DashboardComponent implements OnInit {
       },
       error: (err) => {
         console.error('Erreur récupération statut onglets:', err);
+      }
+    });
+  }
+
+  loadOngletIdsAndStatuses(): void {
+    const ids$ = this.ongletService.getOngletIds(this.entiteId, this.selectedYear);
+    const status$ = this.ongletService.getOngletStatuses(this.entiteId, this.selectedYear);
+    if (!ids$ || !status$) {
+      console.error('Jeton manquant: impossible de récupérer les onglets.');
+      return;
+    }
+
+    forkJoin({ ids: ids$, statuses: status$ }).subscribe({
+      next: ({ ids, statuses }) => {
+        this.ongletIdMap = ids;
+        this.statusService.setStatuses(statuses);
+      },
+      error: (err) => {
+        console.error('Erreur récupération IDs ou statuts des onglets:', err);
+        this.statusService.setStatuses({});
       }
     });
   }

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -5,7 +5,8 @@ const BASE_URL = 'http://localhost:8080';
 export const ApiEndpoints = {
   Onglets: {
     getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`,
-    getAllStatus: (entiteId: number) => `${BASE_URL}/general/status/${entiteId}`
+    // The backend expects the status endpoint in the form /general/{id}/status
+    getAllStatus: (entiteId: number) => `${BASE_URL}/general/${entiteId}/status`
   },
 
   EnergieOnglet: {


### PR DESCRIPTION
## Summary
- point status API to `/general/{id}/status` to match backend

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ccca544548332a26870321d117d58