### PR TITLE
Add energy result service and integrate into synthesis

### DIFF
--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { OngletService } from '../../header-saisie-donnees/onglet.service';
 import { AuthService } from '../../../services/auth.service';
-import { ApiEndpoints } from '../../../services/api-endpoints';
+import { EnergieResultService } from '../../../services/energie-result.service';
 
 interface Sector {
   label: string;
@@ -14,7 +13,7 @@ interface Sector {
 @Component({
   selector: 'app-synthese-eges',
   standalone: true,
-  imports: [CommonModule, HttpClientModule],
+  imports: [CommonModule],
   templateUrl: './synthese-eges-page.component.html',
   styleUrls: ['./synthese-eges-page.component.scss']
 })
@@ -26,9 +25,9 @@ export class SyntheseEgesComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private http: HttpClient,
     private ongletService: OngletService,
-    private auth: AuthService
+    private auth: AuthService,
+    private energieResultService: EnergieResultService
   ) {
     const user = this.auth.getUserInfo()();
     if (user?.entiteId || user?.entiteID) {
@@ -77,22 +76,14 @@ export class SyntheseEgesComponent implements OnInit {
       next: map => {
         const id = map['energieOnglet'];
         if (!id) return;
-        const token = this.auth.getToken();
-        if (!token) return;
-        const headers = {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
-        };
-        this.http
-          .get<{ consoEnergieFinale: number }>(ApiEndpoints.EnergieOnglet.getResult(id.toString()), { headers })
-          .subscribe({
-            next: res => {
-              const sector = this.sectors.find(s => s.label === 'Energie');
-              if (sector) sector.value = Number(res.consoEnergieFinale ?? 0);
-              this.total = this.sectors.reduce((sum, s) => sum + s.value, 0);
-            },
-            error: err => console.error('Erreur récupération énergie', err)
-          });
+        this.energieResultService.getResult(id.toString())?.subscribe({
+          next: res => {
+            const sector = this.sectors.find(s => s.label === 'Energie');
+            if (sector) sector.value = Number(res.consoEnergieFinale ?? 0);
+            this.total = this.sectors.reduce((sum, s) => sum + s.value, 0);
+          },
+          error: err => console.error('Erreur récupération énergie', err)
+        });
       },
       error: err => console.error('Erreur récupération onglet ids', err)
     });

--- a/frontend/src/app/services/energie-result.service.ts
+++ b/frontend/src/app/services/energie-result.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiEndpoints } from './api-endpoints';
+import { AuthService } from './auth.service';
+
+export interface EnergieResult {
+  consoEnergieFinale: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EnergieResultService {
+  constructor(private http: HttpClient, private auth: AuthService) {}
+
+  getResult(ongletId: string): Observable<EnergieResult> | undefined {
+    const token = this.auth.getToken();
+    if (!token) return undefined;
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+    return this.http.get<EnergieResult>(
+      ApiEndpoints.EnergieOnglet.getResult(ongletId),
+      { headers }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `EnergieResultService` to fetch `/energieOnglet/{id}/resultat`
- use new service in `SyntheseEgesComponent`
- remove direct `HttpClient` usage

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3349b308332a886f352ff62dd5e