### PR TITLE
Add service and display energy final consumption

### DIFF
--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
@@ -39,6 +39,15 @@
       </tr>
       </tbody>
     </table>
+
+    <table class="indicator-table">
+      <tbody>
+      <tr>
+        <td>Consommation énergie finale</td>
+        <td>{{ consoEnergieFinale | number:'1.0-2' }} kWh</td>
+      </tr>
+      </tbody>
+    </table>
   </main>
 </div>
 </body>

--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { OngletService } from '../../header-saisie-donnees/onglet.service';
 import { AuthService } from '../../../services/auth.service';
 import { EnergieResultService } from '../../../services/energie-result.service';
+import { EnergieOngletService } from '../../../services/energie-onglet.service';
 
 interface Sector {
   label: string;
@@ -22,12 +23,14 @@ export class SyntheseEgesComponent implements OnInit {
   total: number = 0;
   private currentYear: number = new Date().getFullYear();
   private entiteId?: number;
+  consoEnergieFinale?: number;
 
   constructor(
     private router: Router,
     private ongletService: OngletService,
     private auth: AuthService,
-    private energieResultService: EnergieResultService
+    private energieResultService: EnergieResultService,
+    private energieOngletService: EnergieOngletService
   ) {
     const user = this.auth.getUserInfo()();
     if (user?.entiteId || user?.entiteID) {
@@ -38,6 +41,9 @@ export class SyntheseEgesComponent implements OnInit {
   ngOnInit(): void {
     this.loadSectors();
     this.fetchEnergy();
+    this.energieOngletService
+      .getConsoEnergieFinale(58)
+      .subscribe({ next: v => (this.consoEnergieFinale = v) });
   }
 
   navigateToDashboard() {

--- a/frontend/src/app/services/energie-onglet.service.ts
+++ b/frontend/src/app/services/energie-onglet.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { ApiEndpoints } from './api-endpoints';
+
+interface EnergieResultResponse {
+  consoEnergieFinale: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EnergieOngletService {
+  constructor(private http: HttpClient) {}
+
+  getConsoEnergieFinale(ongletId: number): Observable<number> {
+    return this.http
+      .get<EnergieResultResponse>(
+        ApiEndpoints.EnergieOnglet.getResult(ongletId.toString())
+      )
+      .pipe(map(res => res.consoEnergieFinale));
+  }
+}


### PR DESCRIPTION
## Summary
- implement new EnergieOngletService with method to query energy results
- use this service in SyntheseEgesComponent and display value in template

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd7aa1bbc833292a7c8ef83272a6e