### PR TITLE
Display onglet status with hourglass on dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -24,8 +24,8 @@
   <div class="status-grid">
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(0, 6)">
-        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'green' : 'red'">
-          {{ getStatus(onglet.statusKey) ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'status-termine' : 'status-en-cours'">
+          {{ getStatus(onglet.statusKey) ? '✅' : '⏳' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet)">✏️</span>
@@ -33,8 +33,8 @@
     </div>
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(6)">
-        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'green' : 'red'">
-          {{ getStatus(onglet.statusKey) ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'status-termine' : 'status-en-cours'">
+          {{ getStatus(onglet.statusKey) ? '✅' : '⏳' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet)">✏️</span>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -107,12 +107,12 @@
   margin-right: 0.5em;
 }
 
-.icon.red {
-  color: red;
+.status-termine {
+  color: green;
 }
 
-.icon.green {
-  color: green;
+.status-en-cours {
+  color: orange;
 }
 
 .edit {


### PR DESCRIPTION
## Summary
- show hourglass icon for ongoing tabs on the dashboard
- add css classes `status-termine` and `status-en-cours`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd8def59c833298198f614f652955