### PR TITLE
Implement dashboard tab status display

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -24,8 +24,8 @@
   <div class="status-grid">
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(0, 6)">
-        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'green' : 'red'">
-          {{ getStatus(onglet.statusKey) ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'status-termine' : 'status-en-cours'">
+          {{ getStatus(onglet.statusKey) ? '✅' : '⏳' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet)">✏️</span>
@@ -33,8 +33,8 @@
     </div>
     <div class="column">
       <div class="row" *ngFor="let onglet of onglets.slice(6)">
-        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'green' : 'red'">
-          {{ getStatus(onglet.statusKey) ? '✅' : '❌' }}
+        <span class="icon" [ngClass]="getStatus(onglet.statusKey) ? 'status-termine' : 'status-en-cours'">
+          {{ getStatus(onglet.statusKey) ? '✅' : '⏳' }}
         </span>
         {{ onglet.label }}
         <span class="edit" (click)="goToSaisie(onglet)">✏️</span>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -115,6 +115,14 @@
   color: green;
 }
 
+.status-termine {
+  color: green;
+}
+
+.status-en-cours {
+  color: orange;
+}
+
 .edit {
   font-size: 0.9em;
   color: #555;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -139,6 +139,7 @@ export class DashboardComponent implements OnInit {
   loadOngletStatuses(): void {
     this.ongletService.getOngletStatuses(this.entiteId, this.selectedYear)?.subscribe({
       next: (result) => {
+        this.statuses = result;
         this.statusService.setStatuses(result);
       },
       error: (err) => {


### PR DESCRIPTION
## Summary
- show dashboard tab statuses
- add CSS classes for status icons
- display hourglass for tabs that are not finished

## Testing
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd99abcf483329ee2d257991a9aed