### PR TITLE
Add dashboard status load

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -73,6 +73,15 @@ export class DashboardComponent implements OnInit {
     this.statusService.statuses$.subscribe((s: Record<string, boolean>) => {
       this.statuses = s;
     });
+    this.ongletService
+      .getStatutsParEntiteEtAnnee(this.entiteId, this.currentYear)?.subscribe({
+        next: (result) => {
+          this.statusService.setStatuses(result);
+        },
+        error: (err) => {
+          console.error('Erreur récupération statuts:', err);
+        }
+      });
     this.loadOngletIds();
     this.loadOngletStatuses();
   }

--- a/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
+++ b/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
@@ -35,4 +35,8 @@ export class OngletService {
     const url = `${ApiEndpoints.Onglets.getAllStatus(entiteId)}?annee=${annee}`;
     return this.http.get<{ [key: string]: boolean }>(url, { headers });
   }
+
+  getStatutsParEntiteEtAnnee(entiteId: number, annee: number) {
+    return this.getOngletStatuses(entiteId, annee);
+  }
 }


### PR DESCRIPTION
## Summary
- add `getStatutsParEntiteEtAnnee` helper in `OngletService`
- load statuses on dashboard initialisation with current year

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0fc604f88332a9f590891367759b