### PR TITLE
Fix batiments and entretiens GET mapping

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/batiment-onglet-mapper.service.ts
@@ -15,7 +15,15 @@ import {
 @Injectable({providedIn: 'root'})
 export class BatimentOngletMapperService {
   fromDto(dto: any): BatimentOngletModel {
-    const batiments: BatimentExistantOuNeufConstruit[] = (dto.batimentsExistantOuNeufConstruits || []).map((b: any) => ({
+    const batimentDtoList =
+      dto.batimentsExistantOuNeufConstruits ??
+      dto.batimentExistantOuNeufConstruitList ??
+      dto.batimentsExistantOuNeufConstruitList ??
+      dto.batimentExistantOuNeufConstruits ??
+      dto.batiments ??
+      [];
+
+    const batiments: BatimentExistantOuNeufConstruit[] = (batimentDtoList || []).map((b: any) => ({
       id: b.id,
       nom_ou_adresse: b.nom_ou_adresse ?? '',
       dateConstruction: b.dateConstruction ?? null,
@@ -30,7 +38,15 @@ export class BatimentOngletMapperService {
       dateAjoutEnBase: b.dateAjoutEnBase ?? null,
     }));
 
-    const entretiens: EntretienCourant[] = (dto.entretiensCourants || []).map((e: any) => ({
+    const entretienDtoList =
+      dto.entretiensCourants ??
+      dto.entretienCourantList ??
+      dto.entretiensCourantList ??
+      dto.entretienCourants ??
+      dto.entretiens ??
+      [];
+
+    const entretiens: EntretienCourant[] = (entretienDtoList || []).map((e: any) => ({
       id: e.id,
       dateAjout: e.dateAjout ?? null,
       nom_adresse: e.nom_adresse ?? '',


### PR DESCRIPTION
## Summary
- handle multiple DTO property names when mapping batiments and entretiens

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d132236b883329eed8388297704be