### PR TITLE
Fix dashboard status endpoint

### DIFF
--- a/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
+++ b/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
@@ -32,7 +32,7 @@ export class OngletService {
       Authorization: `Bearer ${token}`
     };
 
-    const url = `${ApiEndpoints.Onglets.getAllStatus(entiteId)}?annee=${annee}`;
+    const url = ApiEndpoints.Onglets.getAllStatus(entiteId, annee);
     return this.http.get<{ [key: string]: boolean }>(url, { headers });
   }
 

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -5,7 +5,8 @@ const BASE_URL = 'http://localhost:8080';
 export const ApiEndpoints = {
   Onglets: {
     getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`,
-    getAllStatus: (entiteId: number) => `${BASE_URL}/general/status/${entiteId}`
+    getAllStatus: (entiteId: number, annee: number) =>
+      `${BASE_URL}/general/${entiteId}/estTermineAnnee/${annee}`
   },
 
   EnergieOnglet: {


### PR DESCRIPTION
## Summary
- update API endpoints for status retrieval
- use updated status endpoint in onglet service

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d16ec8670833291a084ce6c7c3874