### PR TITLE
Fix dashboard status endpoint

### DIFF
--- a/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
+++ b/frontend/src/app/components/header-saisie-donnees/onglet.service.ts
@@ -1,6 +1,7 @@
 // onglet.service.ts
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { forkJoin, map } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { ApiEndpoints } from '../../services/api-endpoints'; // à adapter
 
@@ -32,8 +33,24 @@ export class OngletService {
       Authorization: `Bearer ${token}`
     };
 
-    const url = `${ApiEndpoints.Onglets.getAllStatus(entiteId)}?annee=${annee}`;
-    return this.http.get<{ [key: string]: boolean }>(url, { headers });
+    const idsUrl = `${ApiEndpoints.Onglets.getAllIds(entiteId)}?annee=${annee}`;
+    const statusUrl = ApiEndpoints.Onglets.getAllStatus(entiteId, annee);
+
+    return forkJoin([
+      this.http.get<{ [key: string]: number }>(idsUrl, { headers }),
+      this.http.get<{ [key: string]: boolean }>(statusUrl, { headers })
+    ]).pipe(
+      map(([idsMap, statusMap]) => {
+        const result: Record<string, boolean> = {};
+        for (const [key, id] of Object.entries(idsMap)) {
+          const status = (statusMap as Record<string, boolean>)[id];
+          if (status !== undefined) {
+            result[key] = status;
+          }
+        }
+        return result;
+      })
+    );
   }
 
   getStatutsParEntiteEtAnnee(entiteId: number, annee: number) {

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -5,7 +5,8 @@ const BASE_URL = 'http://localhost:8080';
 export const ApiEndpoints = {
   Onglets: {
     getAllIds: (entiteId: number) => `${BASE_URL}/general/${entiteId}`,
-    getAllStatus: (entiteId: number) => `${BASE_URL}/general/status/${entiteId}`
+    getAllStatus: (entiteId: number, annee: number) =>
+      `${BASE_URL}/general/${entiteId}/estTermineAnnee/${annee}`
   },
 
   EnergieOnglet: {


### PR DESCRIPTION
## Summary
- map status response from backend to onglet keys so the dashboard can display current statuses
- update API endpoints for status retrieval

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d16ec8670833291a084ce6c7c3874