### PR TITLE
Add batiment result service

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import { BatimentResultat } from '../../../models/batiment-resultat.model';
 import {ApiEndpoints} from '../../../services/api-endpoints';
 
 @Injectable({
@@ -39,5 +40,9 @@ export class BatimentsService {
 
   updateOnglet(BatimentsOnglet: string, payload: any, headers: any): Observable<any> {
     return this.http.patch(ApiEndpoints.BatimentsOnglet.update(BatimentsOnglet), payload, { headers });
+  }
+
+  getResult(id: string, headers: any): Observable<BatimentResultat> {
+    return this.http.get<BatimentResultat>(ApiEndpoints.BatimentsOnglet.getResult(id), { headers });
   }
 }

--- a/frontend/src/app/models/batiment-resultat.model.ts
+++ b/frontend/src/app/models/batiment-resultat.model.ts
@@ -1,0 +1,8 @@
+export interface BatimentResultat {
+  emissionGESBatimentExistantOuNeufConstruit: Record<number, number>;
+  emissionGESEntretienCourant: Record<number, number>;
+  emissionGESMobilierElectromenager: Record<number, number>;
+  totalPosteBatiment: number | null;
+  totalPosteEntretien: number | null;
+  totalPosteMobilier: number | null;
+}

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -81,7 +81,8 @@ BatimentsOnglet: {
 
   ajouterMobilier: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}/mobilierElectromenager`,
   supprimerMobilier: (tabId: string, mobilierId: number) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${tabId}/mobilierElectromenager/${mobilierId}`,
-  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}`
+  update: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}`,
+  getResult: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Batiments}/${id}/resultat`
 },
 AutoOnglet: {
   getById: (id: string) => `${BASE_URL}/vehiculeOnglet/${id}`,


### PR DESCRIPTION
## Summary
- add `BatimentResultat` interface
- support retrieving batiment onglet results via `BatimentsService`
- expose new `getResult` API endpoint

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e193cf9388332a9c354a9594f89b8