### PR TITLE
Fix mobilite internationale endpoint name

### DIFF
--- a/frontend/src/app/constants/onglet-keys.ts
+++ b/frontend/src/app/constants/onglet-keys.ts
@@ -3,7 +3,7 @@ export enum ONGLET_KEYS {
   EmissionsFugitives = 'emissionFugitiveOnglet',
   MobiliteDomTrav = 'mobiliteDomicileTravailOnglet',
   AutreMobFr = 'autreMobFrOnglet',
-  MobInternationale = 'mobInternationalOnglet',
+  MobInternationale = 'mobInternationaleOnglet',
   Batiments = 'batimentImmobilisationMobilierOnglet',
   Parkings = 'parkingVoirieOnglet',
   Auto = 'vehiculeOnglet',

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -67,8 +67,8 @@ ParkingVoirieOnglet: {
   getResult: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}/resultat`
 },
 mobInternationaleOnglet: {
-  getById: (id: string) => `${BASE_URL}/mobInternationalOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/mobInternationalOnglet/${id}`
+  getById: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`,
+  update: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`
 },
 BatimentsOnglet: {
   getBatimentImmobilisationMobilier: (id: string) =>


### PR DESCRIPTION
## Summary
- correct onglet key for mobilite internationale
- fix related API endpoints

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e298fe3688332ac4265ecb0cf13cb