### PR TITLE
Fix mobilite internationale key handling

### DIFF
--- a/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
+++ b/frontend/src/app/components/header-saisie-donnees/header-saisie-donnees.component.ts
@@ -17,6 +17,7 @@ import {AuthService} from '../../services/auth.service';
 import {AnneeService} from '../../services/annee.service';
 import {Subscription} from 'rxjs';
 import {ONGLET_ROUTES} from '../../constants/onglet-routes';
+import {ONGLET_KEYS} from '../../constants/onglet-keys';
 
 type YearRange = { label: string; value: number };
 
@@ -105,6 +106,10 @@ export class HeaderSaisieDonneesComponent implements OnInit, AfterViewInit {
   loadOngletIds(): void {
     this.ongletService.getOngletIds(this.entiteId, this.selectedYear)?.subscribe({
       next: (result: { [key: string]: number }) => {
+        if (!result[ONGLET_KEYS.MobInternationale] && result['mobInternationalOnglet']) {
+          result[ONGLET_KEYS.MobInternationale] = result['mobInternationalOnglet'];
+          delete result['mobInternationalOnglet'];
+        }
         this.ongletIdMap = result;
       },
       error: (err: unknown) => {

--- a/frontend/src/app/constants/onglet-keys.ts
+++ b/frontend/src/app/constants/onglet-keys.ts
@@ -3,7 +3,7 @@ export enum ONGLET_KEYS {
   EmissionsFugitives = 'emissionFugitiveOnglet',
   MobiliteDomTrav = 'mobiliteDomicileTravailOnglet',
   AutreMobFr = 'autreMobFrOnglet',
-  MobInternationale = 'mobInternationalOnglet',
+  MobInternationale = 'mobInternationaleOnglet',
   Batiments = 'batimentImmobilisationMobilierOnglet',
   Parkings = 'parkingVoirieOnglet',
   Auto = 'vehiculeOnglet',

--- a/frontend/src/app/services/api-endpoints.ts
+++ b/frontend/src/app/services/api-endpoints.ts
@@ -67,8 +67,8 @@ ParkingVoirieOnglet: {
   getResult: (id: string) => `${BASE_URL}/${ONGLET_KEYS.Parkings}/${id}/resultat`
 },
 mobInternationaleOnglet: {
-  getById: (id: string) => `${BASE_URL}/mobInternationalOnglet/${id}`,
-  update: (id: string) => `${BASE_URL}/mobInternationalOnglet/${id}`
+  getById: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`,
+  update: (id: string) => `${BASE_URL}/mobInternationaleOnglet/${id}`
 },
 BatimentsOnglet: {
   getBatimentImmobilisationMobilier: (id: string) =>


### PR DESCRIPTION
## Summary
- ensure header component imports `ONGLET_KEYS`
- add fallback for legacy `mobInternationalOnglet` key

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e298fe3688332ac4265ecb0cf13cb