### PR TITLE
Fix international mobility mapper

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.ts
@@ -51,7 +51,7 @@ export class MobInterOngletMapperService {
   toVoyageDto(v: Voyage): any {
     return {
       id: v.id,
-      nomPays: this.toBackendPays(v.nomPays),
+      pays: this.toBackendPays(v.nomPays),
       prosAvion: v.prosAvion,
       prosTrain: v.prosTrain,
       stagesEtudiantsAvion: v.stagesEtudiantsAvion,


### PR DESCRIPTION
## Summary
- update mapper to send `pays` instead of `nomPays` in international mobility payload

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2f54a7d08332b568e63704ca04f9