### PR TITLE
Ensure numeric fields default to zero

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.spec.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.spec.ts
@@ -1,0 +1,32 @@
+import { MobInterOngletMapperService } from './mob-inter-onglet-mapper.service';
+import { Voyage } from '../../../models/mob-international.model';
+
+describe('MobInterOngletMapperService', () => {
+  let service: MobInterOngletMapperService;
+
+  beforeEach(() => {
+    service = new MobInterOngletMapperService();
+  });
+
+  it('should convert null or undefined numeric fields to 0', () => {
+    const voyage: Voyage = {
+      id: 1,
+      nomPays: 'France',
+      prosAvion: null,
+      prosTrain: undefined as any,
+      stagesEtudiantsAvion: null,
+      stagesEtudiantsTrain: undefined as any,
+      semestresEtudiantsAvion: null,
+      semestresEtudiantsTrain: undefined as any,
+      dateAjoutEnBase: null,
+    };
+
+    const dto = service.toVoyageDto(voyage);
+    expect(dto.prosAvion).toBe(0);
+    expect(dto.prosTrain).toBe(0);
+    expect(dto.stagesEtudiantsAvion).toBe(0);
+    expect(dto.stagesEtudiantsTrain).toBe(0);
+    expect(dto.semestresEtudiantsAvion).toBe(0);
+    expect(dto.semestresEtudiantsTrain).toBe(0);
+  });
+});

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-onglet-mapper.service.ts
@@ -48,16 +48,22 @@ export class MobInterOngletMapperService {
     };
   }
 
+  /**
+   * Construit l'objet envoyé à l'API. Les champs numériques nuls ou
+   * indéfinis sont convertis en 0 afin d'éviter les erreurs `intValue()`
+   * côté backend.
+   */
   toVoyageDto(v: Voyage): any {
+    const num = (val: number | null | undefined) => val ?? 0;
     return {
       id: v.id,
       pays: this.toBackendPays(v.nomPays),
-      prosAvion: v.prosAvion,
-      prosTrain: v.prosTrain,
-      stagesEtudiantsAvion: v.stagesEtudiantsAvion,
-      stagesEtudiantsTrain: v.stagesEtudiantsTrain,
-      semestresEtudiantsAvion: v.semestresEtudiantsAvion,
-      semestresEtudiantsTrain: v.semestresEtudiantsTrain,
+      prosAvion: num(v.prosAvion),
+      prosTrain: num(v.prosTrain),
+      stagesEtudiantsAvion: num(v.stagesEtudiantsAvion),
+      stagesEtudiantsTrain: num(v.stagesEtudiantsTrain),
+      semestresEtudiantsAvion: num(v.semestresEtudiantsAvion),
+      semestresEtudiantsTrain: num(v.semestresEtudiantsTrain),
       dateAjoutEnBase: v.dateAjoutEnBase,
     };
   }

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.ts
@@ -28,14 +28,18 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
 
   onglet: MobInternationalOngletModel = { voyages: [] };
 
+  /**
+   * Voyage saisi dans le formulaire. Tous les champs numériques sont
+   * initialisés à 0 pour éviter l'envoi de valeurs null lors du PATCH.
+   */
   nouveauVoyage: Voyage = {
     nomPays: '' as any,
-    prosAvion: null,
-    prosTrain: null,
-    stagesEtudiantsAvion: null,
-    stagesEtudiantsTrain: null,
-    semestresEtudiantsAvion: null,
-    semestresEtudiantsTrain: null
+    prosAvion: 0,
+    prosTrain: 0,
+    stagesEtudiantsAvion: 0,
+    stagesEtudiantsTrain: 0,
+    semestresEtudiantsAvion: 0,
+    semestresEtudiantsTrain: 0
   };
 
   ONGLET_KEYS = ONGLET_KEYS;
@@ -78,14 +82,15 @@ export class MobiliteInternationaleSaisieDonneesPageComponent implements OnInit 
 
   ajouterVoyage(): void {
     this.onglet.voyages.push({ ...this.nouveauVoyage });
+    // Réinitialisation avec 0 pour garantir l'envoi d'entiers à l'API
     this.nouveauVoyage = {
       nomPays: '' as any,
-      prosAvion: null,
-      prosTrain: null,
-      stagesEtudiantsAvion: null,
-      stagesEtudiantsTrain: null,
-      semestresEtudiantsAvion: null,
-      semestresEtudiantsTrain: null
+      prosAvion: 0,
+      prosTrain: 0,
+      stagesEtudiantsAvion: 0,
+      stagesEtudiantsTrain: 0,
+      semestresEtudiantsAvion: 0,
+      semestresEtudiantsTrain: 0
     };
     this.updateData();
   }


### PR DESCRIPTION
## Summary
- init numeric fields to 0 in Mobilité Internationale form
- reset form with 0s after adding a voyage
- map `null` or `undefined` numbers to 0 before sending to backend
- test mapper behaviour

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3d0fc49883328f66799f65858890