### PR TITLE
Implement numeric tab results and table

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
-  <div class="left-panel">
+  <div class="panels-wrapper">
+    <div class="left-panel">
     <div class="page-title">
       <h2>Poste numérique</h2>
       <span class="help-icon" title="Merci de renseigner le nombre de chaque type d'équipements en cours d'amortissement comptable, la durée d'amortissement et les émissions de GES précises si celles-ci sont connues (via une ACV / fiche PEP par exemple)">
@@ -58,8 +59,8 @@
     </details>
 
 
-    <div *ngIf="equipementsAnciens.length > 0">
-      <h3>Équipements enregistrés les années précédentes</h3>
+    <div *ngIf="equipements.length > 0" class="added-equipements">
+      <h4>Équipements enregistrés :</h4>
       <table class="data-table">
         <thead>
         <tr>
@@ -69,16 +70,42 @@
           <th>GES Connus</th>
           <th>GES Réels</th>
           <th>Année</th>
+          <th></th>
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let equipement of equipementsAnciens">
+        <tr *ngFor="let equipement of equipements">
           <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
           <td>{{ equipement.nombre }}</td>
           <td>{{ equipement.dureeAmortissement }}</td>
           <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
           <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
           <td>{{ equipement.anneeAjout }}</td>
+          <td><button (click)="supprimerEquipement(equipement.id!)">🗑️</button></td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+    </div>
+    <div class="right-panel">
+      <h3>Résultats calculés</h3>
+      <table class="data-table">
+        <tbody>
+        <tr>
+          <td>Méthode simplifiée</td>
+          <td>{{ resultats?.methodeSimplifieeResultat || 0 }} kgCO₂</td>
+        </tr>
+        <tr>
+          <td>Data center</td>
+          <td>{{ resultats?.empreinteCarboneDataCenter || 0 }} kgCO₂</td>
+        </tr>
+        <tr>
+          <td>Data center + réseaux</td>
+          <td>{{ resultats?.empreinteCarboneDataCenterEtReseaux || 0 }} kgCO₂</td>
+        </tr>
+        <tr>
+          <td>Total numérique</td>
+          <td>{{ resultats?.totalNumerique || 0 }} kgCO₂</td>
         </tr>
         </tbody>
       </table>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
@@ -2,10 +2,6 @@
   background-color: #E6F0FF;
   min-height: 100vh;
   padding: 20px;
-  font-family: Arial, sans-serif;
-  border-radius: 6px;
-  max-width: 800px;
-  margin: auto;
 }
 
 h2, h3 {
@@ -98,4 +94,33 @@ button {
   td {
     background-color: #fdfdfd;
   }
+}
+
+.panels-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 4em;
+  margin-top: 2em;
+  padding: 0 3em;
+  box-sizing: border-box;
+}
+
+.left-panel {
+  width: 60%;
+  box-sizing: border-box;
+}
+
+.right-panel {
+  width: 40%;
+  background-color: #fff;
+  padding: 2em;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+
+.right-panel h3 {
+  text-align: center;
+  margin-bottom: 1rem;
 }

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -10,6 +10,7 @@ import { ONGLET_KEYS } from '../../../constants/onglet-keys';
 import {NumeriqueOngletMapperService} from './numerique-onglet-mapper.service';
 import {NumeriqueService} from './numerique.service';
 import {EquipementNumerique, NumeriqueModel} from '../../../models/numerique.model';
+import {NumeriqueResultat} from '../../../models/numerique-resultat.model';
 import {NUMERIQUE_EQUIPEMENT} from '../../../models/enums/numerique.enum';
 import {numeriqueEquipmentLabels} from '../../../models/numerique-equipment-labels';
 
@@ -48,7 +49,8 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   numeriqueEquipmentLabels = numeriqueEquipmentLabels;
   NUMERIQUE_EQUIPEMENT = NUMERIQUE_EQUIPEMENT;
 
-  equipementsAnciens: EquipementNumerique[] = [];
+  equipements: EquipementNumerique[] = [];
+  resultats: NumeriqueResultat | null = null;
   estTermine = false;
   ONGLET_KEYS = ONGLET_KEYS;
 
@@ -65,6 +67,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.loadData(id);
+      this.loadResultats(id);
     }
   }
 
@@ -87,7 +90,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
         this.traficCloud = model.traficCloud;
         this.tipUtilisateur = model.tipUtilisateur;
         this.partTraficFranceEtranger = model.partTraficFranceEtranger;
-        this.equipementsAnciens = model.equipements;
+        this.equipements = model.equipements;
         this.estTermine = model.estTermine ?? false;
         this.statusService.setStatus(ONGLET_KEYS.Numerique, this.estTermine);
       },
@@ -110,7 +113,10 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
       };
       const dto = this.mapper.toEquipementDto(this.nouvelEquipement);
       this.numeriqueService.addEquipement(id, dto, headers).subscribe({
-        next: () => this.loadData(id),
+        next: () => {
+          this.loadData(id);
+          this.loadResultats(id);
+        },
         error: err => console.error('Erreur ajout équipement', err)
       });
       this.nouvelEquipement = {
@@ -147,7 +153,40 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
 
     const payload = this.mapper.toDto(model);
     this.numeriqueService.updateOnglet(id, payload, headers).subscribe({
+      next: () => this.loadResultats(id),
       error: err => console.error('Erreur lors de la mise à jour des données numériques', err)
+    });
+  }
+
+  supprimerEquipement(idEquip: number): void {
+    const ongletId = this.route.snapshot.paramMap.get('id');
+    const token = this.authService.getToken();
+    if (!ongletId || !token) return;
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+    this.numeriqueService.deleteEquipement(ongletId, idEquip.toString(), headers).subscribe({
+      next: () => {
+        this.loadData(ongletId);
+        this.loadResultats(ongletId);
+      },
+      error: err => console.error('Erreur suppression équipement', err)
+    });
+  }
+
+  loadResultats(id: string) {
+    const token = this.authService.getToken();
+    if (!token) return;
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+    this.numeriqueService.getResult(id, headers).subscribe({
+      next: data => {
+        this.resultats = data;
+      },
+      error: err => console.error('Erreur lors du chargement des résultats numériques', err)
     });
   }
 }

--- a/frontend/src/app/models/numerique-resultat.model.ts
+++ b/frontend/src/app/models/numerique-resultat.model.ts
@@ -1,0 +1,7 @@
+export interface NumeriqueResultat {
+  resultatsEquipementsNumeriques: Record<number, number>;
+  methodeSimplifieeResultat: number | null;
+  empreinteCarboneDataCenter: number | null;
+  empreinteCarboneDataCenterEtReseaux: number | null;
+  totalNumerique: number | null;
+}


### PR DESCRIPTION
## Summary
- add a model for numeric tab results
- display results and equipment table for numeric data input
- style numeric tab with two panels

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e635bb14883328f2c2776242d71e1