### PR TITLE
Implement numeric equipment table layout

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -1,5 +1,6 @@
 <div class="main-container">
-  <div class="left-panel">
+  <div class="panels-wrapper">
+    <div class="left-panel">
     <div class="page-title">
       <h2>Poste numérique</h2>
       <span class="help-icon" title="Merci de renseigner le nombre de chaque type d'équipements en cours d'amortissement comptable, la durée d'amortissement et les émissions de GES précises si celles-ci sont connues (via une ACV / fiche PEP par exemple)">
@@ -58,30 +59,35 @@
     </details>
 
 
-    <div *ngIf="equipementsAnciens.length > 0">
-      <h3>Équipements enregistrés les années précédentes</h3>
-      <table class="data-table">
-        <thead>
-        <tr>
-          <th>Type</th>
-          <th>Quantité</th>
-          <th>Amortissement</th>
-          <th>GES Connus</th>
-          <th>GES Réels</th>
-          <th>Année</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let equipement of equipementsAnciens">
-          <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
-          <td>{{ equipement.nombre }}</td>
-          <td>{{ equipement.dureeAmortissement }}</td>
-          <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
-          <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
-          <td>{{ equipement.anneeAjout }}</td>
-        </tr>
-        </tbody>
-      </table>
+    </div>
+    <div class="right-panel">
+      <div *ngIf="equipements.length > 0" class="added-equipements">
+        <h3>Équipements enregistrés :</h3>
+        <table class="data-table">
+          <thead>
+          <tr>
+            <th>Type</th>
+            <th>Quantité</th>
+            <th>Amortissement</th>
+            <th>GES Connus</th>
+            <th>GES Réels</th>
+            <th>Année</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr *ngFor="let equipement of equipements; let i = index">
+            <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
+            <td>{{ equipement.nombre }}</td>
+            <td>{{ equipement.dureeAmortissement }}</td>
+            <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
+            <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
+            <td>{{ equipement.anneeAjout }}</td>
+            <td><button (click)="supprimerEquipement(i)">🗑️</button></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <app-save-footer [path]="ONGLET_KEYS.Numerique" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
@@ -2,10 +2,6 @@
   background-color: #E6F0FF;
   min-height: 100vh;
   padding: 20px;
-  font-family: Arial, sans-serif;
-  border-radius: 6px;
-  max-width: 800px;
-  margin: auto;
 }
 
 h2, h3 {
@@ -98,4 +94,33 @@ button {
   td {
     background-color: #fdfdfd;
   }
+}
+
+.panels-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 4em;
+  margin-top: 2em;
+  padding: 0 3em;
+  box-sizing: border-box;
+}
+
+.left-panel {
+  width: 60%;
+  box-sizing: border-box;
+}
+
+.right-panel {
+  width: 40%;
+  background-color: #fff;
+  padding: 2em;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+
+.right-panel h3 {
+  text-align: center;
+  margin-bottom: 1rem;
 }

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.ts
@@ -48,7 +48,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
   numeriqueEquipmentLabels = numeriqueEquipmentLabels;
   NUMERIQUE_EQUIPEMENT = NUMERIQUE_EQUIPEMENT;
 
-  equipementsAnciens: EquipementNumerique[] = [];
+  equipements: EquipementNumerique[] = [];
   estTermine = false;
   ONGLET_KEYS = ONGLET_KEYS;
 
@@ -87,7 +87,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
         this.traficCloud = model.traficCloud;
         this.tipUtilisateur = model.tipUtilisateur;
         this.partTraficFranceEtranger = model.partTraficFranceEtranger;
-        this.equipementsAnciens = model.equipements;
+        this.equipements = model.equipements;
         this.estTermine = model.estTermine ?? false;
         this.statusService.setStatus(ONGLET_KEYS.Numerique, this.estTermine);
       },
@@ -99,20 +99,10 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
     if (
       this.nouvelEquipement.nombre !== null &&
       this.nouvelEquipement.dureeAmortissement !== null &&
-      (!this.nouvelEquipement.emissionsGesPrecisesConnues || this.nouvelEquipement.emissionsReellesParProduitKgCO2e !== null)
+      (!this.nouvelEquipement.emissionsGesPrecisesConnues ||
+        this.nouvelEquipement.emissionsReellesParProduitKgCO2e !== null)
     ) {
-      const id = this.route.snapshot.paramMap.get('id');
-      const token = this.authService.getToken();
-      if (!id || !token) return;
-      const headers = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
-      };
-      const dto = this.mapper.toEquipementDto(this.nouvelEquipement);
-      this.numeriqueService.addEquipement(id, dto, headers).subscribe({
-        next: () => this.loadData(id),
-        error: err => console.error('Erreur ajout équipement', err)
-      });
+      this.equipements.push({ ...this.nouvelEquipement });
       this.nouvelEquipement = {
         equipement: NUMERIQUE_EQUIPEMENT.ECRAN,
         nombre: null,
@@ -120,6 +110,7 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
         emissionsGesPrecisesConnues: false,
         emissionsReellesParProduitKgCO2e: null
       };
+      this.updateData();
     }
   }
 
@@ -142,12 +133,17 @@ export class NumeriqueSaisieDonneesPageComponent implements OnInit {
       traficCloud: this.traficCloud,
       tipUtilisateur: this.tipUtilisateur,
       partTraficFranceEtranger: this.partTraficFranceEtranger,
-      equipements: []
+      equipements: this.equipements
     };
 
     const payload = this.mapper.toDto(model);
     this.numeriqueService.updateOnglet(id, payload, headers).subscribe({
       error: err => console.error('Erreur lors de la mise à jour des données numériques', err)
     });
+  }
+
+  supprimerEquipement(index: number): void {
+    this.equipements.splice(index, 1);
+    this.updateData();
   }
 }


### PR DESCRIPTION
## Summary
- refactor numeric tab to follow common data entry pattern
- move saved equipment table to a right panel
- drop unused numeric results model

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e635bb14883328f2c2776242d71e1