### PR TITLE
Update numerique tab layout

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -1,7 +1,5 @@
 <div class="main-container">
-  <div class="panels-wrapper">
-    <div class="left-panel">
-    <div class="page-title">
+  <div class="page-title">
       <h2>Poste numérique</h2>
       <span class="help-icon" title="Merci de renseigner le nombre de chaque type d'équipements en cours d'amortissement comptable, la durée d'amortissement et les émissions de GES précises si celles-ci sont connues (via une ACV / fiche PEP par exemple)">
         <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -10,12 +8,12 @@
           <circle cx="12" cy="8" r="1" fill="white"></circle>
         </svg>
       </span>
-    </div>
-    <p class="question-title">Disposez-vous de données sur le cloud ?</p>
-    <label><input type="radio" name="hasCloud" [(ngModel)]="donneesCloudDisponibles" [value]="true"
-                  (change)="updateData()"/> Oui</label>
-    <label><input type="radio" name="hasCloud" [(ngModel)]="donneesCloudDisponibles" [value]="false"
-                  (change)="updateData()"/> Non</label>
+  </div>
+  <p class="question-title">Disposez-vous de données sur le cloud ?</p>
+  <label><input type="radio" name="hasCloud" [(ngModel)]="donneesCloudDisponibles" [value]="true"
+                (change)="updateData()"/> Oui</label>
+  <label><input type="radio" name="hasCloud" [(ngModel)]="donneesCloudDisponibles" [value]="false"
+                (change)="updateData()"/> Non</label>
 
     <div class="card" *ngIf="donneesCloudDisponibles">
       <label for="cloudTraffic">Trafic cloud (Go)</label>
@@ -57,36 +55,34 @@
 
       <button type="button" (click)="ajouterEquipement()">Ajouter cet équipement</button>
     </details>
-    </div>
-    <div class="right-panel">
-      <div *ngIf="equipements.length > 0" class="added-equipements">
-        <h3>Équipements enregistrés :</h3>
-        <table class="data-table">
-          <thead>
-          <tr>
-            <th>Type</th>
-            <th>Quantité</th>
-            <th>Amortissement</th>
-            <th>GES Connus</th>
-            <th>GES Réels</th>
-            <th>Année</th>
-            <th></th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr *ngFor="let equipement of equipements; let i = index">
-            <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
-            <td>{{ equipement.nombre }}</td>
-            <td>{{ equipement.dureeAmortissement }}</td>
-            <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
-            <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
-            <td>{{ equipement.anneeAjout }}</td>
-            <td><button (click)="supprimerEquipement(i)">🗑️</button></td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+
+  <div *ngIf="equipements.length > 0" class="added-equipements">
+    <h3>Équipements enregistrés :</h3>
+    <table class="data-table">
+      <thead>
+      <tr>
+        <th>Type</th>
+        <th>Quantité</th>
+        <th>Amortissement</th>
+        <th>GES Connus</th>
+        <th>GES Réels</th>
+        <th>Année</th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr *ngFor="let equipement of equipements; let i = index">
+        <td>{{ numeriqueEquipmentLabels[equipement.equipement] }}</td>
+        <td>{{ equipement.nombre }}</td>
+        <td>{{ equipement.dureeAmortissement }}</td>
+        <td>{{ equipement.emissionsGesPrecisesConnues ? 'Oui' : 'Non' }}</td>
+        <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
+        <td>{{ equipement.anneeAjout }}</td>
+        <td><button (click)="supprimerEquipement(i)">🗑️</button></td>
+      </tr>
+      </tbody>
+    </table>
   </div>
+
   <app-save-footer [path]="ONGLET_KEYS.Numerique" (estTermineChange)="onEstTermineChange($event)"></app-save-footer>
 </div>

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.scss
@@ -96,31 +96,3 @@ button {
   }
 }
 
-.panels-wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 4em;
-  margin-top: 2em;
-  padding: 0 3em;
-  box-sizing: border-box;
-}
-
-.left-panel {
-  width: 60%;
-  box-sizing: border-box;
-}
-
-.right-panel {
-  width: 40%;
-  background-color: #fff;
-  padding: 2em;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  box-sizing: border-box;
-}
-
-.right-panel h3 {
-  text-align: center;
-  margin-bottom: 1rem;
-}


### PR DESCRIPTION
## Summary
- align the Numerique page layout with Batiments tab
- remove side panel and display added equipments below the form

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e73ffd73c8332ba78342fb942aacb