### PR TITLE
Fix Autre Immobilisation data mapping

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AutreImmobMapperService {
+  fromDto(dto: any): any {
+    return {
+      pvInstallationGESConnu: dto.installationComplete_IsEmissionGESConnues ?? null,
+      pvInstallationGESReel: dto.installationComplete_EmissionDeGes ?? null,
+      pvPanneauxPuissance: dto.panneaux_PuissanceTotale ?? null,
+      pvPanneauxDuree: dto.panneaux_DureeDeVie ?? null,
+      pvPanneauxGESConnu: dto.panneaux_IsEmissionGESConnues ?? null,
+      pvPanneauxGESReel: dto.panneaux_EmissionDeGes ?? null,
+      pvOnduleursPuissance: dto.onduleur_PuissanceTotale ?? null,
+      pvOnduleursDuree: dto.onduleur_DureeDeVie ?? null,
+      pvOnduleursGESConnu: dto.onduleur_IsEmissionGESConnues ?? null,
+      pvOnduleursGESReel: dto.onduleur_EmissionDeGes ?? null,
+      estTermine: dto.estTermine ?? false,
+      note: dto.note ?? ''
+    };
+  }
+
+  toDto(model: any): any {
+    return {
+      installationComplete_IsEmissionGESConnues: model.pvInstallationGESConnu,
+      installationComplete_EmissionDeGes: model.pvInstallationGESReel,
+      panneaux_PuissanceTotale: model.pvPanneauxPuissance,
+      panneaux_DureeDeVie: model.pvPanneauxDuree,
+      panneaux_IsEmissionGESConnues: model.pvPanneauxGESConnu,
+      panneaux_EmissionDeGes: model.pvPanneauxGESReel,
+      onduleur_PuissanceTotale: model.pvOnduleursPuissance,
+      onduleur_DureeDeVie: model.pvOnduleursDuree,
+      onduleur_IsEmissionGESConnues: model.pvOnduleursGESConnu,
+      onduleur_EmissionDeGes: model.pvOnduleursGESReel,
+      estTermine: model.estTermine,
+      note: model.note
+    };
+  }
+}

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { OngletStatusService } from '../../../services/onglet-status.service';
 import { ONGLET_KEYS } from '../../../constants/onglet-keys';
+import { AutreImmobMapperService } from './autre-immob-mapper.service';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -21,6 +22,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
   private statusService = inject(OngletStatusService);
+  private mapper = inject(AutreImmobMapperService);
 
   items: any = {
     // Photovoltaïque
@@ -92,16 +94,15 @@ export class AutreImmobilisationPageComponent implements OnInit {
       'Authorization': `Bearer ${token}`
     };
 
-    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe(
-      (data) => {
-        this.items = { ...this.items, ...data };
-        this.estTermine = data.estTermine ?? false;
+    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe({
+      next: data => {
+        const mapped = this.mapper.fromDto(data);
+        this.items = { ...this.items, ...mapped };
+        this.estTermine = mapped.estTermine ?? false;
         this.statusService.setStatus(ONGLET_KEYS.AutreImmob, this.estTermine);
       },
-      (error) => {
-        console.error("Erreur lors du chargement des données", error);
-      }
-    );
+      error: err => console.error("Erreur lors du chargement des données", err)
+    });
   }
 
   ajouterMachine() {
@@ -138,7 +139,8 @@ export class AutreImmobilisationPageComponent implements OnInit {
       Authorization: `Bearer ${token}`
     };
 
-    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), { ...this.items, estTermine: this.estTermine }, { headers }).subscribe({
+    const payload = this.mapper.toDto({ ...this.items, estTermine: this.estTermine });
+    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), payload, { headers }).subscribe({
       error: err => console.error('PATCH immob echoue', err)
     });
   }


### PR DESCRIPTION
## Summary
- map backend DTO fields for the "Autre Immobilisation" tab
- use mapper when loading and updating data

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f2a57448332b72ecc0adb845d45