### PR TITLE
Fix Autre Immobilisation field mapping

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
@@ -1,0 +1,159 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AutreImmobMapperService {
+  fromDto(dto: any): any {
+    const machines: any[] = [];
+    const pushMachine = (
+      type: string,
+      nombre: any,
+      poids: any,
+      amortissement: any,
+      gesConnu: any,
+      gesReel: any
+    ) => {
+      if (
+        nombre != null ||
+        poids != null ||
+        amortissement != null ||
+        gesConnu != null ||
+        gesReel != null
+      ) {
+        machines.push({
+          nom: type,
+          nombre: nombre ?? null,
+          poids: poids ?? null,
+          amortissement: amortissement ?? null,
+          gesConnu: gesConnu ?? null,
+          gesReel: gesReel ?? null,
+        });
+      }
+    };
+
+    pushMachine(
+      'groupe',
+      dto.groupesElectrogenes_Nombre,
+      dto.groupesElectrogenes_PoidsDuProduit,
+      dto.groupesElectrogenes_DureeAmortissement,
+      dto.groupesElectrogenes_IsEmissionConnue,
+      dto.groupesElectrogenes_EmissionReelle
+    );
+
+    pushMachine(
+      'moteur',
+      dto.moteurElectrique_Nombre,
+      dto.moteurElectrique_PoidsDuProduit,
+      dto.moteurElectrique_DureeAmortissement,
+      dto.moteurElectrique_IsEmissionConnue,
+      dto.moteurElectrique_EmissionReelle
+    );
+
+    pushMachine(
+      'autresKg',
+      dto.autresMachinesKg_Nombre,
+      dto.autresMachinesKg_PoidsDuProduit,
+      dto.autresMachinesKg_DureeAmortissement,
+      dto.autresMachinesKg_IsEmissionConnue,
+      dto.autresMachinesKg_EmissionReelle
+    );
+
+    pushMachine(
+      'autresEur',
+      dto.autresMachinesEur_Nombre,
+      dto.autresMachinesEur_PoidsDuProduit,
+      dto.autresMachinesEur_DureeAmortissement,
+      dto.autresMachinesEur_IsEmissionConnue,
+      dto.autresMachinesEur_EmissionReelle
+    );
+
+    const hasPvData =
+      dto.installationComplete_PuissanceTotale != null ||
+      dto.panneaux_PuissanceTotale != null ||
+      dto.onduleur_PuissanceTotale != null ||
+      dto.cablageEtStructure_PuissanceTotale != null;
+
+    return {
+      pvInstallationPuissance: dto.installationComplete_PuissanceTotale ?? null,
+      pvInstallationDuree: dto.installationComplete_DureeDeVie ?? null,
+      pvInstallationGESConnu: dto.installationComplete_IsEmissionGESConnues ?? null,
+      pvInstallationGESReel: dto.installationComplete_EmissionDeGes ?? null,
+      pvPanneauxPuissance: dto.panneaux_PuissanceTotale ?? null,
+      pvPanneauxDuree: dto.panneaux_DureeDeVie ?? null,
+      pvPanneauxGESConnu: dto.panneaux_IsEmissionGESConnues ?? null,
+      pvPanneauxGESReel: dto.panneaux_EmissionDeGes ?? null,
+      pvOnduleursPuissance: dto.onduleur_PuissanceTotale ?? null,
+      pvOnduleursDuree: dto.onduleur_DureeDeVie ?? null,
+      pvOnduleursGESConnu: dto.onduleur_IsEmissionGESConnues ?? null,
+      pvOnduleursGESReel: dto.onduleur_EmissionDeGes ?? null,
+      pvCablagePuissance: dto.cablageEtStructure_PuissanceTotale ?? null,
+      pvCablageDuree: dto.cablageEtStructure_DureeDeVie ?? null,
+      pvCablageGESConnu: dto.cablageEtStructure_IsEmissionGESConnues ?? null,
+      pvCablageGESReel: dto.cablageEtStructure_EmissionDeGes ?? null,
+      hasPanneaux: hasPvData,
+      machinesElectriques: machines.length > 0,
+      machines,
+      estTermine: dto.estTermine ?? false,
+      note: dto.note ?? ''
+    };
+  }
+
+  toDto(model: any): any {
+    const payload: any = {
+      installationComplete_PuissanceTotale: model.pvInstallationPuissance,
+      installationComplete_DureeDeVie: model.pvInstallationDuree,
+      installationComplete_IsEmissionGESConnues: model.pvInstallationGESConnu,
+      installationComplete_EmissionDeGes: model.pvInstallationGESReel,
+      panneaux_PuissanceTotale: model.pvPanneauxPuissance,
+      panneaux_DureeDeVie: model.pvPanneauxDuree,
+      panneaux_IsEmissionGESConnues: model.pvPanneauxGESConnu,
+      panneaux_EmissionDeGes: model.pvPanneauxGESReel,
+      onduleur_PuissanceTotale: model.pvOnduleursPuissance,
+      onduleur_DureeDeVie: model.pvOnduleursDuree,
+      onduleur_IsEmissionGESConnues: model.pvOnduleursGESConnu,
+      onduleur_EmissionDeGes: model.pvOnduleursGESReel,
+      cablageEtStructure_PuissanceTotale: model.pvCablagePuissance,
+      cablageEtStructure_DureeDeVie: model.pvCablageDuree,
+      cablageEtStructure_IsEmissionGESConnues: model.pvCablageGESConnu,
+      cablageEtStructure_EmissionDeGes: model.pvCablageGESReel,
+      estTermine: model.estTermine,
+      note: model.note
+    };
+
+    if (Array.isArray(model.machines)) {
+      model.machines.forEach((m: any) => {
+        switch (m.nom) {
+          case 'groupe':
+            payload.groupesElectrogenes_Nombre = m.nombre;
+            payload.groupesElectrogenes_PoidsDuProduit = m.poids;
+            payload.groupesElectrogenes_DureeAmortissement = m.amortissement;
+            payload.groupesElectrogenes_IsEmissionConnue = m.gesConnu;
+            payload.groupesElectrogenes_EmissionReelle = m.gesReel;
+            break;
+          case 'moteur':
+            payload.moteurElectrique_Nombre = m.nombre;
+            payload.moteurElectrique_PoidsDuProduit = m.poids;
+            payload.moteurElectrique_DureeAmortissement = m.amortissement;
+            payload.moteurElectrique_IsEmissionConnue = m.gesConnu;
+            payload.moteurElectrique_EmissionReelle = m.gesReel;
+            break;
+          case 'autresKg':
+            payload.autresMachinesKg_Nombre = m.nombre;
+            payload.autresMachinesKg_PoidsDuProduit = m.poids;
+            payload.autresMachinesKg_DureeAmortissement = m.amortissement;
+            payload.autresMachinesKg_IsEmissionConnue = m.gesConnu;
+            payload.autresMachinesKg_EmissionReelle = m.gesReel;
+            break;
+          case 'autresEur':
+            payload.autresMachinesEur_Nombre = m.nombre;
+            payload.autresMachinesEur_PoidsDuProduit = m.poids;
+            payload.autresMachinesEur_DureeAmortissement = m.amortissement;
+            payload.autresMachinesEur_IsEmissionConnue = m.gesConnu;
+            payload.autresMachinesEur_EmissionReelle = m.gesReel;
+            break;
+        }
+      });
+    }
+
+    return payload;
+  }
+}

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -11,8 +11,8 @@
       </span>
     </div>
     <p class="question-title">Avez-vous des panneaux photovoltaïques ?</p>
-    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="true"/> Oui</label>
-    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="false"/> Non</label>
+    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="true" (change)="updateData()"/> Oui</label>
+    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="false" (change)="updateData()"/> Non</label>
 
     <div *ngIf="items.hasPanneaux">
       <h3>Si oui :</h3>
@@ -29,39 +29,51 @@
         <tbody>
         <tr>
           <td>Installation complète</td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvInstallationGESConnu">
+            <select [(ngModel)]="items.pvInstallationGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel" (blur)="updateData()"/></td>
         </tr>
         <tr>
           <td>Panneaux</td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvPanneauxGESConnu">
+            <select [(ngModel)]="items.pvPanneauxGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel" (blur)="updateData()"/></td>
         </tr>
         <tr>
           <td>Onduleurs</td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvOnduleursGESConnu">
+            <select [(ngModel)]="items.pvOnduleursGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel" (blur)="updateData()"/></td>
+        </tr>
+        <tr>
+          <td>Câblage / structure</td>
+          <td><input type="number" [(ngModel)]="items.pvCablagePuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvCablageDuree" (blur)="updateData()"/></td>
+          <td>
+            <select [(ngModel)]="items.pvCablageGESConnu" (change)="updateData()">
+              <option [value]="true">Oui</option>
+              <option [value]="false">Non</option>
+            </select>
+          </td>
+          <td><input type="number" [(ngModel)]="items.pvCablageGESReel" (blur)="updateData()"/></td>
         </tr>
         </tbody>
       </table>
@@ -70,9 +82,9 @@
     <hr/>
 
     <p class="question-title">Avez-vous des machines électriques ?</p>
-    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="true"/>
+    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="true" (change)="updateData()"/>
       Oui</label>
-    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="false"/> Non</label>
+    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="false" (change)="updateData()"/> Non</label>
 
     <div *ngIf="items.machinesElectriques">
       <div class="machine-section">

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { OngletStatusService } from '../../../services/onglet-status.service';
 import { ONGLET_KEYS } from '../../../constants/onglet-keys';
+import { AutreImmobMapperService } from './autre-immob-mapper.service';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -21,6 +22,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
   private statusService = inject(OngletStatusService);
+  private mapper = inject(AutreImmobMapperService);
 
   items: any = {
     // Photovoltaïque
@@ -45,6 +47,12 @@ export class AutreImmobilisationPageComponent implements OnInit {
     pvOnduleursDuree: null,
     pvOnduleursGESConnu: '',
     pvOnduleursGESReel: null,
+
+    // Câblage / Structure
+    pvCablagePuissance: null,
+    pvCablageDuree: null,
+    pvCablageGESConnu: '',
+    pvCablageGESReel: null,
 
     // Machines
     machinesElectriques: false,
@@ -92,16 +100,15 @@ export class AutreImmobilisationPageComponent implements OnInit {
       'Authorization': `Bearer ${token}`
     };
 
-    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe(
-      (data) => {
-        this.items = { ...this.items, ...data };
-        this.estTermine = data.estTermine ?? false;
+    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe({
+      next: data => {
+        const mapped = this.mapper.fromDto(data);
+        this.items = { ...this.items, ...mapped };
+        this.estTermine = mapped.estTermine ?? false;
         this.statusService.setStatus(ONGLET_KEYS.AutreImmob, this.estTermine);
       },
-      (error) => {
-        console.error("Erreur lors du chargement des données", error);
-      }
-    );
+      error: err => console.error("Erreur lors du chargement des données", err)
+    });
   }
 
   ajouterMachine() {
@@ -121,6 +128,8 @@ export class AutreImmobilisationPageComponent implements OnInit {
     this.items.machineAmortissement = null;
     this.items.machineGESConnu = '';
     this.items.machineGESReel = null;
+
+    this.updateData();
   }
 
   supprimerMachine(index: number): void {
@@ -138,7 +147,8 @@ export class AutreImmobilisationPageComponent implements OnInit {
       Authorization: `Bearer ${token}`
     };
 
-    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), { ...this.items, estTermine: this.estTermine }, { headers }).subscribe({
+    const payload = this.mapper.toDto({ ...this.items, estTermine: this.estTermine });
+    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), payload, { headers }).subscribe({
       error: err => console.error('PATCH immob echoue', err)
     });
   }


### PR DESCRIPTION
## Summary
- capture cablage/structure values in Autre Immobilisation page
- map these new fields to the backend DTO
- include a row for cablage/structure in the photovoltaic table

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f2a57448332b72ecc0adb845d45