### PR TITLE
Fix Autre Immobilisation field mapping

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/achats/achats-saisie-donnees-page.component.html
@@ -41,19 +41,19 @@
 
     <h2>Poste restauration</h2>
     <p>Avez-vous déjà calculé le bilan carbone du poste restauration ?</p>
-    <label><input type="radio" name="hasBilanCarbone" [(ngModel)]="items.hasBilanCarbone" [value]="true" /> Oui</label>
-    <label><input type="radio" name="hasBilanCarbone" [(ngModel)]="items.hasBilanCarbone" [value]="false" /> Non</label>
+    <label><input type="radio" name="hasBilanCarbone" [(ngModel)]="items.hasBilanCarbone" [value]="true" (change)="updateAchat()"/> Oui</label>
+    <label><input type="radio" name="hasBilanCarbone" [(ngModel)]="items.hasBilanCarbone" [value]="false" (change)="updateAchat()"/> Non</label>
 
     <div *ngIf="items.hasBilanCarbone">
       <label>Bilan carbone total (tCO2e/an) :
-        <input type="number" [(ngModel)]="items.bilanCarboneTotal" />
+        <input type="number" [(ngModel)]="items.bilanCarboneTotal" (blur)="updateAchat()" />
       </label>
     </div>
 
     <div *ngIf="items.hasBilanCarbone === false">
       <p>Connaissez-vous la quantité d'aliments consommés (en tonnes) ?</p>
-      <label><input type="radio" name="quantiteAliments" [(ngModel)]="items.connaitQuantiteAliments" [value]="true" /> Oui</label>
-      <label><input type="radio" name="quantiteAliments" [(ngModel)]="items.connaitQuantiteAliments" [value]="false" /> Non</label>
+      <label><input type="radio" name="quantiteAliments" [(ngModel)]="items.connaitQuantiteAliments" [value]="true" (change)="updateAchat()"/> Oui</label>
+      <label><input type="radio" name="quantiteAliments" [(ngModel)]="items.connaitQuantiteAliments" [value]="false" (change)="updateAchat()"/> Non</label>
 
       <div *ngIf="items.connaitQuantiteAliments">
         <table class="data-table">
@@ -72,8 +72,8 @@
 
       <div *ngIf="items.connaitQuantiteAliments === false">
         <p>Connaissez-vous le nombre de repas consommés dans l'année par type ?</p>
-        <label><input type="radio" name="repasParType" [(ngModel)]="items.connaitRepasParType" [value]="true" /> Oui</label>
-        <label><input type="radio" name="repasParType" [(ngModel)]="items.connaitRepasParType" [value]="false" /> Non</label>
+        <label><input type="radio" name="repasParType" [(ngModel)]="items.connaitRepasParType" [value]="true" (change)="updateAchat()"/> Oui</label>
+        <label><input type="radio" name="repasParType" [(ngModel)]="items.connaitRepasParType" [value]="false" (change)="updateAchat()"/> Non</label>
 
         <div *ngIf="items.connaitRepasParType">
           <table class="data-table">

--- a/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/auto/auto-saisie-donnees-page.component.html
@@ -15,20 +15,20 @@
 
       <div class="form-column">
         <label>Modèle / Immatriculation</label>
-        <input type="text" [(ngModel)]="nouveauVehicule.modeleOuImmatriculation" />
+        <input type="text" [(ngModel)]="nouveauVehicule.modeleOuImmatriculation" (blur)="updateData()" />
 
         <label>Type de véhicule</label>
-        <select [(ngModel)]="nouveauVehicule.typeVehicule">
+        <select [(ngModel)]="nouveauVehicule.typeVehicule" (change)="updateData()">
           <option *ngFor="let type of vehiculeTypesLibelles" [ngValue]="type.value">
             {{ type.label }}
           </option>
         </select>
 
         <label>Nombre de véhicules identiques</label>
-        <input type="number" [(ngModel)]="nouveauVehicule.nombreVehiculesIdentiques" />
+        <input type="number" [(ngModel)]="nouveauVehicule.nombreVehiculesIdentiques" (blur)="updateData()" />
 
         <label>Nombre de Km moyen annuel / Voiture</label>
-        <input type="number" [(ngModel)]="nouveauVehicule.nombreKilometresParVoitureMoyen" />
+        <input type="number" [(ngModel)]="nouveauVehicule.nombreKilometresParVoitureMoyen" (blur)="updateData()" />
       </div>
 
       <button type="button" (click)="ajouterVehicule()">Ajouter ce véhicule</button>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/autre-immob-mapper.service.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AutreImmobMapperService {
+  fromDto(dto: any): any {
+    const machines: any[] = [];
+    const pushMachine = (
+      type: string,
+      nombre: any,
+      poids: any,
+      amortissement: any,
+      gesConnu: any,
+      gesReel: any
+    ) => {
+      if (
+        nombre != null ||
+        poids != null ||
+        amortissement != null ||
+        gesConnu != null ||
+        gesReel != null
+      ) {
+        machines.push({
+          nom: type,
+          nombre: nombre ?? null,
+          poids: poids ?? null,
+          amortissement: amortissement ?? null,
+          gesConnu: gesConnu ?? null,
+          gesReel: gesReel ?? null,
+        });
+      }
+    };
+
+    pushMachine(
+      'groupe',
+      dto.groupesElectrogenes_Nombre,
+      dto.groupesElectrogenes_PoidsDuProduit,
+      dto.groupesElectrogenes_DureeAmortissement,
+      dto.groupesElectrogenes_IsEmissionConnue,
+      dto.groupesElectrogenes_EmissionReelle
+    );
+
+    pushMachine(
+      'moteur',
+      dto.moteurElectrique_Nombre,
+      dto.moteurElectrique_PoidsDuProduit,
+      dto.moteurElectrique_DureeAmortissement,
+      dto.moteurElectrique_IsEmissionConnue,
+      dto.moteurElectrique_EmissionReelle
+    );
+
+    pushMachine(
+      'autresKg',
+      dto.autresMachinesKg_Nombre,
+      dto.autresMachinesKg_PoidsDuProduit,
+      dto.autresMachinesKg_DureeAmortissement,
+      dto.autresMachinesKg_IsEmissionConnue,
+      dto.autresMachinesKg_EmissionReelle
+    );
+
+    pushMachine(
+      'autresEur',
+      dto.autresMachinesEur_Nombre,
+      dto.autresMachinesEur_PoidsDuProduit,
+      dto.autresMachinesEur_DureeAmortissement,
+      dto.autresMachinesEur_IsEmissionConnue,
+      dto.autresMachinesEur_EmissionReelle
+    );
+
+    const hasPvData =
+      dto.installationComplete_PuissanceTotale != null ||
+      dto.panneaux_PuissanceTotale != null ||
+      dto.onduleur_PuissanceTotale != null ||
+      dto.cablageEtStructure_PuissanceTotale != null;
+
+    return {
+      pvInstallationPuissance: dto.installationComplete_PuissanceTotale ?? null,
+      pvInstallationDuree: dto.installationComplete_DureeDeVie ?? null,
+      pvInstallationGESConnu: dto.installationComplete_IsEmissionGESConnues ?? null,
+      pvInstallationGESReel: dto.installationComplete_EmissionDeGes ?? null,
+      pvPanneauxPuissance: dto.panneaux_PuissanceTotale ?? null,
+      pvPanneauxDuree: dto.panneaux_DureeDeVie ?? null,
+      pvPanneauxGESConnu: dto.panneaux_IsEmissionGESConnues ?? null,
+      pvPanneauxGESReel: dto.panneaux_EmissionDeGes ?? null,
+      pvOnduleursPuissance: dto.onduleur_PuissanceTotale ?? null,
+      pvOnduleursDuree: dto.onduleur_DureeDeVie ?? null,
+      pvOnduleursGESConnu: dto.onduleur_IsEmissionGESConnues ?? null,
+      pvOnduleursGESReel: dto.onduleur_EmissionDeGes ?? null,
+      pvCablagePuissance: dto.cablageEtStructure_PuissanceTotale ?? null,
+      pvCablageDuree: dto.cablageEtStructure_DureeDeVie ?? null,
+      pvCablageGESConnu: dto.cablageEtStructure_IsEmissionGESConnues ?? null,
+      pvCablageGESReel: dto.cablageEtStructure_EmissionDeGes ?? null,
+      hasPanneaux: hasPvData,
+      machinesElectriques: machines.length > 0,
+      machines,
+      estTermine: dto.estTermine ?? false,
+      note: dto.note ?? ''
+    };
+  }
+
+  toDto(model: any): any {
+    const payload: any = {
+      installationComplete_PuissanceTotale: model.pvInstallationPuissance,
+      installationComplete_DureeDeVie: model.pvInstallationDuree,
+      installationComplete_IsEmissionGESConnues: model.pvInstallationGESConnu,
+      installationComplete_EmissionDeGes: model.pvInstallationGESReel,
+      panneaux_PuissanceTotale: model.pvPanneauxPuissance,
+      panneaux_DureeDeVie: model.pvPanneauxDuree,
+      panneaux_IsEmissionGESConnues: model.pvPanneauxGESConnu,
+      panneaux_EmissionDeGes: model.pvPanneauxGESReel,
+      onduleur_PuissanceTotale: model.pvOnduleursPuissance,
+      onduleur_DureeDeVie: model.pvOnduleursDuree,
+      onduleur_IsEmissionGESConnues: model.pvOnduleursGESConnu,
+      onduleur_EmissionDeGes: model.pvOnduleursGESReel,
+      cablageEtStructure_PuissanceTotale: model.pvCablagePuissance,
+      cablageEtStructure_DureeDeVie: model.pvCablageDuree,
+      cablageEtStructure_IsEmissionGESConnues: model.pvCablageGESConnu,
+      cablageEtStructure_EmissionDeGes: model.pvCablageGESReel,
+      estTermine: model.estTermine,
+      note: model.note
+    };
+
+    const map: Record<string, any> = {};
+
+    if (Array.isArray(model.machines)) {
+      model.machines.forEach((m: any) => {
+        map[m.nom] = m;
+      });
+    }
+
+    const groupe = map['groupe'] || {};
+    payload.groupesElectrogenes_Nombre = groupe.nombre ?? null;
+    payload.groupesElectrogenes_PoidsDuProduit = groupe.poids ?? null;
+    payload.groupesElectrogenes_DureeAmortissement = groupe.amortissement ?? null;
+    payload.groupesElectrogenes_IsEmissionConnue = groupe.gesConnu ?? null;
+    payload.groupesElectrogenes_EmissionReelle = groupe.gesReel ?? null;
+
+    const moteur = map['moteur'] || {};
+    payload.moteurElectrique_Nombre = moteur.nombre ?? null;
+    payload.moteurElectrique_PoidsDuProduit = moteur.poids ?? null;
+    payload.moteurElectrique_DureeAmortissement = moteur.amortissement ?? null;
+    payload.moteurElectrique_IsEmissionConnue = moteur.gesConnu ?? null;
+    payload.moteurElectrique_EmissionReelle = moteur.gesReel ?? null;
+
+    const autresKg = map['autresKg'] || {};
+    payload.autresMachinesKg_Nombre = autresKg.nombre ?? null;
+    payload.autresMachinesKg_PoidsDuProduit = autresKg.poids ?? null;
+    payload.autresMachinesKg_DureeAmortissement = autresKg.amortissement ?? null;
+    payload.autresMachinesKg_IsEmissionConnue = autresKg.gesConnu ?? null;
+    payload.autresMachinesKg_EmissionReelle = autresKg.gesReel ?? null;
+
+    const autresEur = map['autresEur'] || {};
+    payload.autresMachinesEur_Nombre = autresEur.nombre ?? null;
+    payload.autresMachinesEur_PoidsDuProduit = autresEur.poids ?? null;
+    payload.autresMachinesEur_DureeAmortissement = autresEur.amortissement ?? null;
+    payload.autresMachinesEur_IsEmissionConnue = autresEur.gesConnu ?? null;
+    payload.autresMachinesEur_EmissionReelle = autresEur.gesReel ?? null;
+
+    return payload;
+  }
+}

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -11,8 +11,8 @@
       </span>
     </div>
     <p class="question-title">Avez-vous des panneaux photovoltaïques ?</p>
-    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="true"/> Oui</label>
-    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="false"/> Non</label>
+    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="true" (change)="updateData()"/> Oui</label>
+    <label><input type="radio" name="hasPanneaux" [(ngModel)]="items.hasPanneaux" [value]="false" (change)="updateData()"/> Non</label>
 
     <div *ngIf="items.hasPanneaux">
       <h3>Si oui :</h3>
@@ -29,39 +29,51 @@
         <tbody>
         <tr>
           <td>Installation complète</td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvInstallationGESConnu">
+            <select [(ngModel)]="items.pvInstallationGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel" (blur)="updateData()"/></td>
         </tr>
         <tr>
           <td>Panneaux</td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvPanneauxGESConnu">
+            <select [(ngModel)]="items.pvPanneauxGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel" (blur)="updateData()"/></td>
         </tr>
         <tr>
           <td>Onduleurs</td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursPuissance"/></td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursDuree"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursPuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvOnduleursGESConnu">
+            <select [(ngModel)]="items.pvOnduleursGESConnu" (change)="updateData()">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel" (blur)="updateData()"/></td>
+        </tr>
+        <tr>
+          <td>Câblage / structure</td>
+          <td><input type="number" [(ngModel)]="items.pvCablagePuissance" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvCablageDuree" (blur)="updateData()"/></td>
+          <td>
+            <select [(ngModel)]="items.pvCablageGESConnu" (change)="updateData()">
+              <option [value]="true">Oui</option>
+              <option [value]="false">Non</option>
+            </select>
+          </td>
+          <td><input type="number" [(ngModel)]="items.pvCablageGESReel" (blur)="updateData()"/></td>
         </tr>
         </tbody>
       </table>
@@ -70,35 +82,35 @@
     <hr/>
 
     <p class="question-title">Avez-vous des machines électriques ?</p>
-    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="true"/>
+    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="true" (change)="onMachinesElectriquesChange(true)"/>
       Oui</label>
-    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="false"/> Non</label>
+    <label><input type="radio" name="machinesElectriques" [(ngModel)]="items.machinesElectriques" [value]="false" (change)="onMachinesElectriquesChange(false)"/> Non</label>
 
     <div *ngIf="items.machinesElectriques">
       <div class="machine-section">
         <label>Type :
-          <select [(ngModel)]="items.machineType">
+          <select [(ngModel)]="items.machineType" (change)="updateData()">
             <option value="groupe">Groupe électrogène</option>
             <option value="autre">Autre</option>
           </select>
         </label>
         <label>Nombre :
-          <input type="number" [(ngModel)]="items.machineNombre"/>
+          <input type="number" [(ngModel)]="items.machineNombre" (blur)="updateData()"/>
         </label>
         <label>Poids du produit :
-          <input type="number" [(ngModel)]="items.machinePoids"/> Kg
+          <input type="number" [(ngModel)]="items.machinePoids" (blur)="updateData()"/> Kg
         </label>
         <label>Durée d’amortissement :
-          <input type="number" [(ngModel)]="items.machineAmortissement"/>
+          <input type="number" [(ngModel)]="items.machineAmortissement" (blur)="updateData()"/>
         </label>
         <label>Émissions de GES réelles connues ?
-          <select [(ngModel)]="items.machineGESConnu">
+          <select [(ngModel)]="items.machineGESConnu" (change)="updateData()">
             <option [value]="true">Oui</option>
             <option [value]="false">Non</option>
           </select>
         </label>
         <label>Émissions de GES réelles (tCO2e/an):
-          <input type="number" [(ngModel)]="items.machineGESReel"/>
+          <input type="number" [(ngModel)]="items.machineGESReel" (blur)="updateData()"/>
         </label>
 
         <button type="button" (click)="ajouterMachine()">Ajouter cet équipement</button>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../services/auth.service';
 import { ApiEndpoints } from '../../../services/api-endpoints';
 import { OngletStatusService } from '../../../services/onglet-status.service';
 import { ONGLET_KEYS } from '../../../constants/onglet-keys';
+import { AutreImmobMapperService } from './autre-immob-mapper.service';
 
 @Component({
   selector: 'app-saisie-donnees-page',
@@ -21,6 +22,7 @@ export class AutreImmobilisationPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
   private statusService = inject(OngletStatusService);
+  private mapper = inject(AutreImmobMapperService);
 
   items: any = {
     // Photovoltaïque
@@ -45,6 +47,12 @@ export class AutreImmobilisationPageComponent implements OnInit {
     pvOnduleursDuree: null,
     pvOnduleursGESConnu: '',
     pvOnduleursGESReel: null,
+
+    // Câblage / Structure
+    pvCablagePuissance: null,
+    pvCablageDuree: null,
+    pvCablageGESConnu: '',
+    pvCablageGESReel: null,
 
     // Machines
     machinesElectriques: false,
@@ -92,16 +100,15 @@ export class AutreImmobilisationPageComponent implements OnInit {
       'Authorization': `Bearer ${token}`
     };
 
-    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe(
-      (data) => {
-        this.items = { ...this.items, ...data };
-        this.estTermine = data.estTermine ?? false;
+    this.http.get<any>(ApiEndpoints.autreImmobilisationOnglet.getById(id), { headers }).subscribe({
+      next: data => {
+        const mapped = this.mapper.fromDto(data);
+        this.items = { ...this.items, ...mapped };
+        this.estTermine = mapped.estTermine ?? false;
         this.statusService.setStatus(ONGLET_KEYS.AutreImmob, this.estTermine);
       },
-      (error) => {
-        console.error("Erreur lors du chargement des données", error);
-      }
-    );
+      error: err => console.error("Erreur lors du chargement des données", err)
+    });
   }
 
   ajouterMachine() {
@@ -121,6 +128,16 @@ export class AutreImmobilisationPageComponent implements OnInit {
     this.items.machineAmortissement = null;
     this.items.machineGESConnu = '';
     this.items.machineGESReel = null;
+
+    this.updateData();
+  }
+
+  onMachinesElectriquesChange(value: boolean): void {
+    this.items.machinesElectriques = value;
+    if (!value) {
+      this.items.machines = [];
+    }
+    this.updateData();
   }
 
   supprimerMachine(index: number): void {
@@ -138,7 +155,8 @@ export class AutreImmobilisationPageComponent implements OnInit {
       Authorization: `Bearer ${token}`
     };
 
-    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), { ...this.items, estTermine: this.estTermine }, { headers }).subscribe({
+    const payload = this.mapper.toDto({ ...this.items, estTermine: this.estTermine });
+    this.http.patch(ApiEndpoints.autreImmobilisationOnglet.update(id), payload, { headers }).subscribe({
       error: err => console.error('PATCH immob echoue', err)
     });
   }

--- a/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/batiments/bat-saisie-donnees-page.component.html
@@ -16,30 +16,30 @@ Les bâtiments qui ont été renseignées les années précédentes sont encore 
     <summary><strong>Saisir un nouveau bâtiment</strong></summary>
 
     <label>Nom / Adresse :
-      <input type="text" [(ngModel)]="nouveauBatiment.nom_ou_adresse"/>
+      <input type="text" [(ngModel)]="nouveauBatiment.nom_ou_adresse" (blur)="updateData()"/>
     </label>
 
     <label>Date de construction :
-      <input type="date" [(ngModel)]="nouveauBatiment.dateConstruction"/>
+      <input type="date" [(ngModel)]="nouveauBatiment.dateConstruction" (blur)="updateData()"/>
     </label>
 
     <label>Date de la dernière rénovation complète :
-      <input type="date" [(ngModel)]="nouveauBatiment.dateDerniereGrosseRenovation"/>
+      <input type="date" [(ngModel)]="nouveauBatiment.dateDerniereGrosseRenovation" (blur)="updateData()"/>
     </label>
 
     <label>Avez-vous une ACV de ce bâtiment ?
-      <select [(ngModel)]="nouveauBatiment.acvBatimentRealisee">
+      <select [(ngModel)]="nouveauBatiment.acvBatimentRealisee" (change)="updateData()">
         <option [ngValue]="true">Oui</option>
         <option [ngValue]="false">Non</option>
       </select>
     </label>
 
     <label *ngIf="nouveauBatiment.acvBatimentRealisee">Émissions de GES réelles (tCO2e/an) :
-      <input type="number" [(ngModel)]="nouveauBatiment.emissionsGesReellesTCO2"/>
+      <input type="number" [(ngModel)]="nouveauBatiment.emissionsGesReellesTCO2" (blur)="updateData()"/>
     </label>
 
     <label>Type de bâtiment :
-      <select [(ngModel)]="nouveauBatiment.typeBatiment">
+      <select [(ngModel)]="nouveauBatiment.typeBatiment" (change)="updateData()">
         <option *ngFor="let type of batimentTypesLibelles" [ngValue]="type.value">
           {{ type.label }}
         </option>
@@ -47,11 +47,11 @@ Les bâtiments qui ont été renseignées les années précédentes sont encore 
     </label>
 
     <label>Surface (m²) :
-      <input type="number" [(ngModel)]="nouveauBatiment.surfaceEnM2"/>
+      <input type="number" [(ngModel)]="nouveauBatiment.surfaceEnM2" (blur)="updateData()"/>
     </label>
 
     <label>Type de structure :
-      <select [(ngModel)]="nouveauBatiment.typeStructure">
+      <select [(ngModel)]="nouveauBatiment.typeStructure" (change)="updateData()">
         <option *ngFor="let structure of structureTypesLibelles" [ngValue]="structure.value">
           {{ structure.label }}
         </option>
@@ -110,11 +110,11 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     <summary><strong>Saisir une rénovation ponctuelle</strong></summary>
 
     <label>Nom du bâtiment :
-      <input type="text" [(ngModel)]="nouvelleReno.nom_adresse"/>
+      <input type="text" [(ngModel)]="nouvelleReno.nom_adresse" (blur)="updateData()"/>
     </label>
 
     <label>Type de travaux :
-      <select [(ngModel)]="nouvelleReno.typeTravaux">
+      <select [(ngModel)]="nouvelleReno.typeTravaux" (change)="updateData()">
         <option *ngFor="let travaux of travauxTypesLibelles" [ngValue]="travaux.value">
           {{ travaux.label }}
         </option>
@@ -122,11 +122,11 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     </label>
 
     <label>Date des travaux :
-      <input type="date" [(ngModel)]="nouvelleReno.dateTravaux"/>
+      <input type="date" [(ngModel)]="nouvelleReno.dateTravaux" (blur)="updateData()"/>
     </label>
 
     <label>Type de bâtiment :
-      <select [(ngModel)]="nouvelleReno.typeBatiment">
+      <select [(ngModel)]="nouvelleReno.typeBatiment" (change)="updateData()">
         <option *ngFor="let type of batimentTypesLibelles" [ngValue]="type.value">
           {{ type.label }}
         </option>
@@ -134,11 +134,11 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     </label>
 
     <label>Surface (m²) :
-      <input type="number" [(ngModel)]="nouvelleReno.surfaceConcernee"/>
+      <input type="number" [(ngModel)]="nouvelleReno.surfaceConcernee" (blur)="updateData()"/>
     </label>
 
     <label>Durée amortissement (année) :
-      <input type="number" [(ngModel)]="nouvelleReno.dureeAmortissement"/>
+      <input type="number" [(ngModel)]="nouvelleReno.dureeAmortissement" (blur)="updateData()"/>
     </label>
 
     <button (click)="ajouterEntretien()">Ajouter cette rénovation</button>
@@ -189,7 +189,7 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     <summary><strong>Saisir du mobilier</strong></summary>
 
     <label>Type de mobilier :
-      <select [(ngModel)]="nouveauMobilier.mobilier">
+      <select [(ngModel)]="nouveauMobilier.mobilier" (change)="updateData()">
         <option *ngFor="let type of mobilierTypesLibelles" [ngValue]="type.value">
           {{ type.label }}
         </option>
@@ -197,15 +197,15 @@ Merci de ne renseigner que vos travaux de l'année, l'outil réintègre automati
     </label>
 
     <label>Nombre :
-      <input type="number" [(ngModel)]="nouveauMobilier.quantite"/>
+      <input type="number" [(ngModel)]="nouveauMobilier.quantite" (blur)="updateData()"/>
     </label>
 
     <label>Poids (kg) :
-      <input type="number" [(ngModel)]="nouveauMobilier.poidsDuProduit"/>
+      <input type="number" [(ngModel)]="nouveauMobilier.poidsDuProduit" (blur)="updateData()"/>
     </label>
 
     <label>Durée amortissement (année) :
-      <input type="number" [(ngModel)]="nouveauMobilier.dureeAmortissement"/>
+      <input type="number" [(ngModel)]="nouveauMobilier.dureeAmortissement" (blur)="updateData()"/>
     </label>
 
     <button (click)="ajouterMobilier()">Ajouter ce mobilier</button>

--- a/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/mob-inter/mob-inter-saisie-donnees-page.component.html
@@ -16,7 +16,7 @@
 
       <div class="form-column">
         <label>Quel est le pays de destination ?
-          <select [(ngModel)]="nouveauVoyage.nomPays">
+          <select [(ngModel)]="nouveauVoyage.nomPays" (change)="updateData()">
             <option *ngFor="let pays of listePays" [value]="pays">{{ pays }}</option>
           </select>
         </label>
@@ -33,15 +33,15 @@
           <tbody>
             <tr>
               <td>Avion</td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.prosAvion" /></td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.stagesEtudiantsAvion" /></td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.semestresEtudiantsAvion" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.prosAvion" (blur)="updateData()" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.stagesEtudiantsAvion" (blur)="updateData()" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.semestresEtudiantsAvion" (blur)="updateData()" /></td>
             </tr>
             <tr>
               <td>Train / Bus</td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.prosTrain" /></td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.stagesEtudiantsTrain" /></td>
-              <td><input type="number" [(ngModel)]="nouveauVoyage.semestresEtudiantsTrain" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.prosTrain" (blur)="updateData()" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.stagesEtudiantsTrain" (blur)="updateData()" /></td>
+              <td><input type="number" [(ngModel)]="nouveauVoyage.semestresEtudiantsTrain" (blur)="updateData()" /></td>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/park/park-saisie-donnees-page.component.html
@@ -15,38 +15,38 @@
 
       <div class="form-column">
         <label>Nom / Adresse :
-          <input type="text" [(ngModel)]="nouveauParking.nomOuAdresse" />
+          <input type="text" [(ngModel)]="nouveauParking.nomOuAdresse" (blur)="updateData()" />
         </label>
 
         <label>Date de construction :
-          <input type="date" [(ngModel)]="nouveauParking.dateConstruction" />
+          <input type="date" [(ngModel)]="nouveauParking.dateConstruction" (blur)="updateData()" />
         </label>
 
         <label>Type :
-          <select [(ngModel)]="nouveauParking.type">
+          <select [(ngModel)]="nouveauParking.type" (change)="updateData()">
             <option *ngFor="let t of parkingTypes" [ngValue]="t">{{ t }}</option>
           </select>
         </label>
 
         <label>Surface (m²) :
-          <input type="number" [(ngModel)]="nouveauParking.nombreM2" />
+          <input type="number" [(ngModel)]="nouveauParking.nombreM2" (blur)="updateData()" />
         </label>
 
         <label>Type de structure :
-          <select [(ngModel)]="nouveauParking.typeStructure">
+          <select [(ngModel)]="nouveauParking.typeStructure" (change)="updateData()">
             <option *ngFor="let ts of structureTypes" [ngValue]="ts">{{ ts }}</option>
           </select>
         </label>
 
         <label>Émissions de GES connues ?
-          <select [(ngModel)]="nouveauParking.emissionsGesConnues" (ngModelChange)="onEmissionsConnuesChange($event)">
+          <select [(ngModel)]="nouveauParking.emissionsGesConnues" (ngModelChange)="onEmissionsConnuesChange($event); updateData()">
             <option [ngValue]="false">Non</option>
             <option [ngValue]="true">Oui</option>
           </select>
         </label>
 
         <label *ngIf="nouveauParking.emissionsGesConnues">Émissions de GES réelles (tCO2e/an) :
-          <input type="number" [(ngModel)]="nouveauParking.emissionsGesReelles" />
+          <input type="number" [(ngModel)]="nouveauParking.emissionsGesReelles" (blur)="updateData()" />
         </label>
       </div>
 


### PR DESCRIPTION
## Summary
- capture cablage/structure values in Autre Immobilisation page
- map these new fields to the backend DTO
- include a row for cablage/structure in the photovoltaic table
- clear machine data when toggling off and always send machine fields in patch
- trigger updates on blur for inputs across data entry pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f2a57448332b72ecc0adb845d45