### PR TITLE
Lock GES reel when emissions unknown

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.html
@@ -28,36 +28,39 @@
           <td></td>
           <td></td>
           <td>
-            <select [(ngModel)]="items.pvInstallationGESConnu" (change)="updateData()">
+            <select [(ngModel)]="items.pvInstallationGESConnu" (change)="onGesConnuChange('pvInstallationGESConnu','pvInstallationGESReel')">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvInstallationGESReel" (blur)="updateData()"
+                     [disabled]="items.pvInstallationGESConnu === false || items.pvInstallationGESConnu === 'false'"/></td>
         </tr>
         <tr>
           <td>Panneaux</td>
           <td><input type="number" [(ngModel)]="items.pvPanneauxPuissance" (blur)="updateData()"/></td>
           <td><input type="number" [(ngModel)]="items.pvPanneauxDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvPanneauxGESConnu" (change)="updateData()">
+            <select [(ngModel)]="items.pvPanneauxGESConnu" (change)="onGesConnuChange('pvPanneauxGESConnu','pvPanneauxGESReel')">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvPanneauxGESReel" (blur)="updateData()"
+                     [disabled]="items.pvPanneauxGESConnu === false || items.pvPanneauxGESConnu === 'false'"/></td>
         </tr>
         <tr>
           <td>Onduleurs</td>
           <td><input type="number" [(ngModel)]="items.pvOnduleursPuissance" (blur)="updateData()"/></td>
           <td><input type="number" [(ngModel)]="items.pvOnduleursDuree" (blur)="updateData()"/></td>
           <td>
-            <select [(ngModel)]="items.pvOnduleursGESConnu" (change)="updateData()">
+            <select [(ngModel)]="items.pvOnduleursGESConnu" (change)="onGesConnuChange('pvOnduleursGESConnu','pvOnduleursGESReel')">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
-          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel" (blur)="updateData()"/></td>
+          <td><input type="number" [(ngModel)]="items.pvOnduleursGESReel" (blur)="updateData()"
+                     [disabled]="items.pvOnduleursGESConnu === false || items.pvOnduleursGESConnu === 'false'"/></td>
         </tr>
         </tbody>
       </table>
@@ -92,13 +95,14 @@
             <input type="number" [(ngModel)]="machine.amortissement" (blur)="updateData()"/>
           </td>
           <td>
-            <select [(ngModel)]="machine.gesConnu" (change)="updateData()">
+            <select [(ngModel)]="machine.gesConnu" (change)="onMachineGesConnuChange(machine)">
               <option [value]="true">Oui</option>
               <option [value]="false">Non</option>
             </select>
           </td>
           <td>
-            <input type="number" [(ngModel)]="machine.gesReel" (blur)="updateData()"/>
+            <input type="number" [(ngModel)]="machine.gesReel" (blur)="updateData()"
+                   [disabled]="machine.gesConnu === false || machine.gesConnu === 'false'"/>
           </td>
         </tr>
         </tbody>

--- a/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
+++ b/frontend/src/app/components/saisie-donnees-page/autre-immob/immob-donnees-page.component.ts
@@ -145,6 +145,21 @@ export class AutreImmobilisationPageComponent implements OnInit {
     this.updateData();
   }
 
+  onGesConnuChange(connuKey: string, reelKey: string): void {
+    const value = this.items[connuKey];
+    if (value === false || value === 'false') {
+      this.items[reelKey] = null;
+    }
+    this.updateData();
+  }
+
+  onMachineGesConnuChange(machine: any): void {
+    if (machine.gesConnu === false || machine.gesConnu === 'false') {
+      machine.gesReel = null;
+    }
+    this.updateData();
+  }
+
   updateData(): void {
     const id = this.route.snapshot.paramMap.get('id');
     const token = this.authService.getToken();


### PR DESCRIPTION
## Summary
- disable GES réel field when the corresponding "GES connues" select is set to false in Autres immobilisations
- clear the real GES value when disabling

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f84d8757c8332bc70ee6e346fd4bc