### PR TITLE
Fill scope table values

### DIFF
--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.ts
@@ -132,7 +132,41 @@ export class SyntheseEgesComponent implements OnInit {
             }
           });
 
+          const scopesMapping: Record<string, number | null | undefined> = {
+            'Emissions directes des sources fixes de combustion': res.emissionDirecteCombustion,
+            'Emissions directes des sources mobiles à moteur thermique': res.emissionDirecteMoteurThermique,
+            'Emissions directes des procédés hors énergie': res.emissionDirecteHorsEnergie,
+            'Emissions directes fugitives': res.emissionDirecteFugitives,
+            'Emissions issues de la biomasse (sols et forêts)': res.emissionBiomasse,
+            "Emissions indirectes liées à la consommation d'électricité": res.emissionIndirecteConsoElec,
+            'Emissions indirectes liées à la consommation de vapeur, chaleur, froid': res.emissionIndirecteConsoVapeurChaleurFroid,
+            "Emissions liées à l'énergie non incluse dans les catégories « émissions directes de GES » et « émissions de GES à énergie indirectes »": res.emissionNonIncluseDansDirectOuIndirecte,
+            'Achats de produits ou services': res.achatProduitOuService,
+            'Immobilisations de biens': res.immobilisationBien,
+            'Déchets': res.dechet,
+            'Transport de marchandise amont': res.transportMarchandiseAmont,
+            'Déplacements professionnels': res.deplacementProfessionnel,
+            'Actifs en leasing amont': res.leasingAmont,
+            'Investissements': res.investissement,
+            'Transport de visiteurs et de clients': res.transportVisiteursClients,
+            'Transport de marchandise aval': res.transportMarchandiseAval,
+            'Utilisation des produits vendus': res.utilisationProduitVendu,
+            'Fin de vie des produits vendus': res.finVieProduitVendu,
+            'Franchise aval': res.franchiseAval,
+            'Leasing aval': res.leasingAval,
+            'Déplacements domicile travail': res.deplacementDomicileTravail,
+            'Autres émissions indirectes': res.autreEmissionIndirecte
+          };
+
+          this.scopes.forEach(sc => {
+            const val = scopesMapping[sc.label];
+            if (val != null) {
+              sc.value = Number(val);
+            }
+          });
+
           this.total = Number(res.bilanCarboneTotalGlobal ?? 0);
+          this.scopesTotal = Number(res.bilanCarboneTotalScope ?? 0);
           if (res.consoEnergieFinale != null) {
             this.consoEnergieFinale = res.consoEnergieFinale;
           }

--- a/frontend/src/app/services/synthese-eges.service.ts
+++ b/frontend/src/app/services/synthese-eges.service.ts
@@ -16,7 +16,35 @@ export interface SyntheseEgesResult {
   achatGlobal: number | null;
   dechetGlobal: number | null;
   bilanCarboneTotalGlobal: number | null;
+  /** Sum of scope/poste values returned by the API */
+  bilanCarboneTotalScope?: number | null;
+  /** Scope/poste values */
+  emissionDirecteCombustion?: number | null;
+  emissionDirecteMoteurThermique?: number | null;
+  emissionDirecteHorsEnergie?: number | null;
+  emissionDirecteFugitives?: number | null;
+  emissionBiomasse?: number | null;
+  emissionIndirecteConsoElec?: number | null;
+  emissionIndirecteConsoVapeurChaleurFroid?: number | null;
+  emissionNonIncluseDansDirectOuIndirecte?: number | null;
+  achatProduitOuService?: number | null;
+  immobilisationBien?: number | null;
+  dechet?: number | null;
+  transportMarchandiseAmont?: number | null;
+  deplacementProfessionnel?: number | null;
+  leasingAmont?: number | null;
+  investissement?: number | null;
+  transportVisiteursClients?: number | null;
+  transportMarchandiseAval?: number | null;
+  utilisationProduitVendu?: number | null;
+  finVieProduitVendu?: number | null;
+  franchiseAval?: number | null;
+  leasingAval?: number | null;
+  deplacementDomicileTravail?: number | null;
+  autreEmissionIndirecte?: number | null;
   consoEnergieFinale?: number | null;
+  /** Any other numeric fields returned by the API */
+  [key: string]: number | null | undefined;
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary
- extend `SyntheseEgesResult` with scope related properties
- populate the scope/poste table from the API response

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f85f9134883329e59418818742d24