### PR TITLE
Move day count row to separate table

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.html
@@ -17,7 +17,7 @@
         <thead>
         <tr>
           <th>Moyen de transport</th>
-          <th *ngFor="let group of travelerGroups">{{ group }} (km)</th>
+          <th *ngFor="let group of travelerGroups">{{ group }} (jours)</th>
         </tr>
         </thead>
         <tbody>
@@ -40,7 +40,17 @@
             />
           </td>
         </tr>
+        </tbody>
+      </table>
 
+      <table class="data-table">
+        <thead>
+        <tr>
+          <th>Moyen de transport</th>
+          <th *ngFor="let group of travelerGroups">{{ group }} (km)</th>
+        </tr>
+        </thead>
+        <tbody>
         <tr *ngFor="let mode of transportModes">
           <td>{{ mode }}</td>
           <td *ngFor="let group of travelerGroups">

--- a/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.scss
+++ b/frontend/src/app/components/saisie-donnees-page/dom-trav/dom-trav-saisie-donnees-page.component.scss
@@ -71,6 +71,10 @@ th {
   text-align: center;
 }
 
+.data-table + .data-table {
+  margin-top: 1.5em;
+}
+
 .page-title {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- split the number of travel days row into its own table
- add spacing between the two tables

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f86a1a1fc8332bea5a17ddaa42859