### PR TITLE
Compléter l'onglet numérique avec nouvelle donnée et résultats

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -21,6 +21,9 @@
 
       <label for="tipUtilisateur">TIP utilisateur</label>
       <input id="tipUtilisateur" type="number" [(ngModel)]="tipUtilisateur" (blur)="updateData()"/>
+
+      <label for="partTrafic">Part trafic France / Étranger (%)</label>
+      <input id="partTrafic" type="number" [(ngModel)]="partTraficFranceEtranger" (blur)="updateData()"/>
     </div>
 
     <hr/>
@@ -79,6 +82,30 @@
         <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
         <td>{{ equipement.anneeAjout }}</td>
         <td><button (click)="supprimerEquipement(i)">🗑️</button></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div *ngIf="resultats" class="results">
+    <h3>Résultats calculés</h3>
+    <table class="data-table">
+      <tbody>
+      <tr>
+        <td>Méthode simplifiée</td>
+        <td>{{ resultats?.methodeSimplifieeResultat || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Empreinte carbone data center</td>
+        <td>{{ resultats?.empreinteCarboneDataCenter || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Empreinte carbone data center + réseaux</td>
+        <td>{{ resultats?.empreinteCarboneDataCenterEtReseaux || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Total numérique</td>
+        <td>{{ resultats?.totalNumerique || 0 }} kgCO2e</td>
       </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- ajouter la saisie de la part du trafic France/Étranger dans l'onglet numérique
- afficher les résultats calculés du poste numérique

## Testing
- `npm test` *(échoue : `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f86bb7e7c833285ff2f5ba289d17f