### PR TITLE
Compléter l'onglet numérique avec nouvelle donnée et résultats

### DIFF
--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-onglet-mapper.service.ts
@@ -27,7 +27,10 @@ export class NumeriqueOngletMapperService {
       cloudDataDisponible: dto.cloudDataDisponible ?? null,
       traficCloud: dto.TraficCloudUtilisateur != null ? Number(dto.TraficCloudUtilisateur) : null,
       tipUtilisateur: dto.TraficTipUtilisateur != null ? Number(dto.TraficTipUtilisateur) : null,
-      partTraficFranceEtranger: dto.PartTraficFranceEtranger != null ? Number(dto.PartTraficFranceEtranger) : null,
+      partTraficFranceEtranger:
+        dto.PartTraficFranceEtranger != null && !isNaN(Number(dto.PartTraficFranceEtranger))
+          ? Number(dto.PartTraficFranceEtranger)
+          : null,
       equipements,
     };
   }
@@ -39,7 +42,10 @@ export class NumeriqueOngletMapperService {
       cloudDataDisponible: model.cloudDataDisponible,
       TraficCloudUtilisateur: model.traficCloud != null ? Number(model.traficCloud) : null,
       TraficTipUtilisateur: model.tipUtilisateur != null ? Number(model.tipUtilisateur) : null,
-      PartTraficFranceEtranger: model.partTraficFranceEtranger != null ? Number(model.partTraficFranceEtranger) : null,
+      PartTraficFranceEtranger:
+        model.partTraficFranceEtranger != null && !isNaN(Number(model.partTraficFranceEtranger))
+          ? Number(model.partTraficFranceEtranger)
+          : null,
       equipementNumeriqueList: model.equipements.map((e: EquipementNumerique) => ({
         id: e.id,
         equipement: typeof e.equipement === 'string' ? e.equipement : (e.equipement as NUMERIQUE_EQUIPEMENT).toString(),

--- a/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
+++ b/frontend/src/app/components/saisie-donnees-page/numerique/numerique-saisie-donnees-page.component.html
@@ -21,6 +21,9 @@
 
       <label for="tipUtilisateur">TIP utilisateur</label>
       <input id="tipUtilisateur" type="number" [(ngModel)]="tipUtilisateur" (blur)="updateData()"/>
+
+      <label for="partTrafic">Part trafic France / Étranger (%)</label>
+      <input id="partTrafic" type="number" [(ngModel)]="partTraficFranceEtranger" (blur)="updateData()"/>
     </div>
 
     <hr/>
@@ -79,6 +82,30 @@
         <td>{{ equipement.emissionsReellesParProduitKgCO2e ?? 'N/A' }}</td>
         <td>{{ equipement.anneeAjout }}</td>
         <td><button (click)="supprimerEquipement(i)">🗑️</button></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div *ngIf="resultats" class="results">
+    <h3>Résultats calculés</h3>
+    <table class="data-table">
+      <tbody>
+      <tr>
+        <td>Méthode simplifiée</td>
+        <td>{{ resultats?.methodeSimplifieeResultat || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Empreinte carbone data center</td>
+        <td>{{ resultats?.empreinteCarboneDataCenter || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Empreinte carbone data center + réseaux</td>
+        <td>{{ resultats?.empreinteCarboneDataCenterEtReseaux || 0 }} kgCO2e</td>
+      </tr>
+      <tr>
+        <td>Total numérique</td>
+        <td>{{ resultats?.totalNumerique || 0 }} kgCO2e</td>
       </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- ajouter la saisie de la part du trafic France/Étranger dans l'onglet numérique
- afficher les résultats calculés du poste numérique
- valider la valeur du trafic France/Étranger avant mapping

## Testing
- `npm test` *(échoue : `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f86bb7e7c833285ff2f5ba289d17f