### PR TITLE
Fix tab button order on summary and tracking pages

### DIFF
--- a/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.html
+++ b/frontend/src/app/components/affichage-graphiques/suivi/trajectoire-page.component.html
@@ -14,8 +14,8 @@
 
   <nav class="tabs">
     <div class="tabs-container">
-      <button class="tab-button" (click)="goToRecap()">Récap</button>
       <button class="tab-button active">Suivi</button>
+      <button class="tab-button" (click)="goToRecap()">Récap</button>
     </div>
   </nav>
 

--- a/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
+++ b/frontend/src/app/components/affichage-graphiques/synthese/synthese-eges-page.component.html
@@ -14,8 +14,8 @@
 
   <nav class="tabs">
     <div class="tabs-container">
-      <button class="tab-button active">Récap</button>
       <button class="tab-button" (click)="goToSuivi()">Suivi</button>
+      <button class="tab-button active">Récap</button>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- reverse "Suivi" and "Récap" buttons for consistency on Synthese and Trajectoire pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc8c1800c8332ae5f2fa5f9a2cc8e